### PR TITLE
NestedFactory::create Unit tests

### DIFF
--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -291,12 +291,11 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         bool _fromReserve
     ) private returns (uint256 feesAmount, IERC20 tokenSold) {
         _inputToken = _transferInputTokens(_nftId, _inputToken, _inputTokenAmount, _fromReserve);
-
         uint256 amountSpent;
         for (uint256 i = 0; i < _orders.length; i++) {
             amountSpent += _submitOrder(_inputToken, _orders[i].token, _nftId, _orders[i], _reserved);
         }
-        uint256 fees = _calculateFees(msg.sender, _inputTokenAmount);
+        uint256 fees = _calculateFees(msg.sender, amountSpent);
         assert(amountSpent <= _inputTokenAmount - fees); // overspent
 
         // If input is from the reserve, update the records

--- a/contracts/libraries/ExchangeHelpers.sol
+++ b/contracts/libraries/ExchangeHelpers.sol
@@ -18,7 +18,7 @@ library ExchangeHelpers {
     function fillQuote(
         IERC20 _sellToken,
         address _swapTarget,
-        bytes calldata _swapCallData
+        bytes memory _swapCallData
     ) internal returns (bool) {
         setMaxAllowance(_sellToken, _swapTarget);
         // solhint-disable-next-line avoid-low-level-calls

--- a/contracts/operators/ZeroEx/IZeroExOperator.sol
+++ b/contracts/operators/ZeroEx/IZeroExOperator.sol
@@ -9,6 +9,7 @@ interface IZeroExOperator {
     /// @param own The operator address (for delegatecall context resolution)
     /// @param sellToken The token sold
     /// @param buyToken The token bought
+    /// @param swapSelector The selector of the ZeroEx function
     /// @param swapCallData 0x calldata from the API
     /// @return amounts Array of output amounts
     /// @return tokens Array of output tokens
@@ -16,6 +17,7 @@ interface IZeroExOperator {
         address own,
         IERC20 sellToken,
         IERC20 buyToken,
+        bytes4 swapSelector,
         bytes calldata swapCallData
-    ) external returns (uint256[] memory amounts, address[] memory tokens);
+    ) external payable returns (uint256[] memory amounts, address[] memory tokens);
 }

--- a/contracts/operators/ZeroEx/ZeroExOperator.sol
+++ b/contracts/operators/ZeroEx/ZeroExOperator.sol
@@ -23,14 +23,15 @@ contract ZeroExOperator is IZeroExOperator, IOperatorSelector {
         address own,
         IERC20 sellToken,
         IERC20 buyToken,
+        bytes4 swapSelector,
         bytes calldata swapCallData
-    ) external override returns (uint256[] memory amounts, address[] memory tokens) {
+    ) external payable override returns (uint256[] memory amounts, address[] memory tokens) {
         amounts = new uint[](1);
         tokens = new address[](1);
         address swapTarget = ZeroExStorage(storageAddress(own)).swapTarget();
         uint256 balanceBeforePurchase = buyToken.balanceOf(address(this));
 
-        bool success = ExchangeHelpers.fillQuote(sellToken, swapTarget, swapCallData);
+        bool success = ExchangeHelpers.fillQuote(sellToken, swapTarget, bytes.concat(swapSelector, swapCallData[32:]));
         require(success, "ZeroExOperator::commitAndRevert: 0x swap failed");
 
         uint256 amountBought = buyToken.balanceOf(address(this)) - balanceBeforePurchase;

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -92,7 +92,9 @@ export const zeroExOperatorFixture: Fixture<ZeroExOperatorFixture> = async (wall
 
     const mockERC20Factory = await ethers.getContractFactory("MockERC20");
     const mockUNI = await mockERC20Factory.deploy("Mocked UNI", "UNI", appendDecimals(3000000));
+    await mockUNI.deployed();
     const mockDAI = await mockERC20Factory.deploy("Mocked DAI", "DAI", appendDecimals(3000000));
+    await mockDAI.deployed();
 
     await mockUNI.transfer(dummyRouter.address, appendDecimals(1000));
     await mockDAI.transfer(dummyRouter.address, appendDecimals(1000));
@@ -283,6 +285,11 @@ export const factoryAndZeroExFixture: Fixture<FactoryAndZeroExFixture> = async (
     await mockUNI.connect(masterDeployer).transfer(user1.address, baseAmount);
     await mockKNC.connect(masterDeployer).transfer(user1.address, baseAmount);
     await mockDAI.connect(masterDeployer).transfer(user1.address, baseAmount);
+
+    // User1 approves factory to spend all his tokens (UNI, KNC, and DAI)
+    await mockUNI.connect(user1).approve(nestedFactory.address, baseAmount);
+    await mockKNC.connect(user1).approve(nestedFactory.address, baseAmount);
+    await mockDAI.connect(user1).approve(nestedFactory.address, baseAmount);
 
     return {
         WETH,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22816913/135491330-bf17e0fd-4941-485a-9c37-27496b2fef8d.png)

Includes the unit tests for the create function and some fixes : 
- Wrong amount for fees computation (_submitInOrders) used to check the amount spent. Must apply on the amount spent by the operator and not the theoretical input amount.
- Operator functions must be payable, because the factory is payable too (cause an error if the input is ETH).
- Extract selector from calldata to solve wrong padding caused by the selector (bytes4) inside the calldata.