### PR TITLE
Peckshield PVE001 & PVE002

### DIFF
--- a/contracts/NestedBuybacker.sol
+++ b/contracts/NestedBuybacker.sol
@@ -97,7 +97,6 @@ contract NestedBuybacker is Ownable {
         }
 
         uint256 balance = _sellToken.balanceOf(address(this));
-        _sellToken.approve(_swapTarget, balance);
         ExchangeHelpers.fillQuote(_sellToken, _swapTarget, _swapCallData);
         trigger();
         emit BuybackTriggered(_sellToken);

--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -153,7 +153,7 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         IERC20 _sellToken,
         uint256 _sellTokenAmount,
         Order[] calldata _orders
-    ) external payable override nonReentrant onlyTokenOwner(_nftId) isUnlocked(_nftId) {
+    ) external override nonReentrant onlyTokenOwner(_nftId) isUnlocked(_nftId) {
         require(_orders.length > 0, "NestedFactory::swapTokenForTokens: Missing orders");
         require(
             nestedRecords.getAssetReserve(_nftId) == address(reserve),
@@ -172,7 +172,7 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         IERC20 _buyToken,
         uint256[] memory _sellTokensAmount,
         Order[] calldata _orders
-    ) external payable override nonReentrant onlyTokenOwner(_nftId) isUnlocked(_nftId) {
+    ) external override nonReentrant onlyTokenOwner(_nftId) isUnlocked(_nftId) {
         require(_orders.length > 0, "NestedFactory::sellTokensToNft: Missing orders");
         require(_sellTokensAmount.length == _orders.length, "NestedFactory::sellTokensToNft: Input lengths must match");
         require(
@@ -192,15 +192,21 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         IERC20 _buyToken,
         uint256[] memory _sellTokensAmount,
         Order[] calldata _orders
-    ) external payable override nonReentrant onlyTokenOwner(_nftId) isUnlocked(_nftId) {
+    ) external override nonReentrant onlyTokenOwner(_nftId) isUnlocked(_nftId) {
         require(_orders.length > 0, "NestedFactory::sellTokensToWallet: Missing orders");
         require(
             _sellTokensAmount.length == _orders.length,
             "NestedFactory::sellTokensToWallet: Input lengths must match"
         );
 
-        (uint256 feesAmount, uint256 amountBought) =
-            _submitOutOrders(_nftId, _buyToken, _sellTokensAmount, _orders, false, true);
+        (uint256 feesAmount, uint256 amountBought) = _submitOutOrders(
+            _nftId,
+            _buyToken,
+            _sellTokensAmount,
+            _orders,
+            false,
+            true
+        );
         _transferFeeWithRoyalty(feesAmount, _buyToken, _nftId);
         _safeTransferAndUnwrap(_buyToken, amountBought - feesAmount, msg.sender);
 
@@ -333,8 +339,12 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         uint256 _outputTokenInitialBalance = _outputToken.balanceOf(address(this));
 
         for (uint256 i = 0; i < _orders.length; i++) {
-            IERC20 _inputToken =
-                _transferInputTokens(_nftId, IERC20(_orders[i].token), _inputTokenAmounts[i], _fromReserve);
+            IERC20 _inputToken = _transferInputTokens(
+                _nftId,
+                IERC20(_orders[i].token),
+                _inputTokenAmounts[i],
+                _fromReserve
+            );
 
             // Submit order and update holding of spent token
             uint256 amountSpent = _submitOrder(_inputToken, address(_outputToken), _nftId, _orders[i], false);
@@ -518,7 +528,7 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         }
     }
 
-    /// @dev Transfer from factory and collect fees (without royalties)
+    /// @dev Transfer from factory and collect fees
     /// @param _token The token to transfer
     /// @param _amount The amount (with fees) to transfer
     /// @param _dest The address receiving the funds

--- a/contracts/NestedRecords.sol
+++ b/contracts/NestedRecords.sol
@@ -44,7 +44,7 @@ contract NestedRecords is Ownable {
     uint256 public maxHoldingsCount;
 
     /// @dev Reverts the transaction if the caller is not the factory
-    modifier onlyFactory {
+    modifier onlyFactory() {
         require(supportedFactories[msg.sender], "NestedRecords: FORBIDDEN");
         _;
     }
@@ -199,15 +199,6 @@ contract NestedRecords is Ownable {
         records[_nftId].reserve = _nextReserve;
     }
 
-    /// @notice Remove a token from the array of tokens in assetTokens. Does not remove holding record
-    /// @param _nftId ID for the NFT
-    /// @param _tokenIndex Token index to delete in the array of tokens
-    function freeToken(uint256 _nftId, uint256 _tokenIndex) public onlyFactory {
-        address[] storage tokens = records[_nftId].tokens;
-        tokens[_tokenIndex] = tokens[tokens.length - 1];
-        tokens.pop();
-    }
-
     /// @notice Delete from mapping assetTokens
     /// @param _nftId The id of the NFT
     function removeNFT(uint256 _nftId) external onlyFactory {
@@ -228,29 +219,12 @@ contract NestedRecords is Ownable {
         freeToken(_nftId, _tokenIndex);
     }
 
-    /// @notice Update NFT data into our mappings
-    /// @param _nftId The id of the NFT
-    /// @param _tokenIndex The token index
-    /// @param _token The address of the token
-    /// @param _amountSold The amount of tokens sold
-    function update(
-        uint256 _nftId,
-        uint256 _tokenIndex,
-        address _token,
-        uint256 _amountSold
-    ) external onlyFactory {
-        Holding memory holding = records[_nftId].holdings[_token];
-        require(holding.isActive, "ALREADY_SOLD");
-        uint256 remainingAmount = holding.amount - _amountSold;
-
-        // update amount or delete if nothing remaining
-        if (remainingAmount > 0) {
-            records[_nftId].holdings[_token].amount = holding.amount - _amountSold;
-        } else {
-            delete records[_nftId].holdings[_token];
-            address[] storage tokens = records[_nftId].tokens;
-            tokens[_tokenIndex] = tokens[tokens.length - 1];
-            tokens.pop();
-        }
+    /// @dev Remove a token from the array of tokens in assetTokens. Does not remove holding record
+    /// @param _nftId ID for the NFT
+    /// @param _tokenIndex Token index to delete in the array of tokens
+    function freeToken(uint256 _nftId, uint256 _tokenIndex) private {
+        address[] storage tokens = records[_nftId].tokens;
+        tokens[_tokenIndex] = tokens[tokens.length - 1];
+        tokens.pop();
     }
 }

--- a/contracts/interfaces/INestedFactory.sol
+++ b/contracts/interfaces/INestedFactory.sol
@@ -105,7 +105,7 @@ interface INestedFactory {
         IERC20 _sellToken,
         uint256 _sellTokenAmount,
         Order[] calldata _orders
-    ) external payable;
+    ) external;
 
     /// @notice Use one or more existing tokens from the NFT for one position.
     /// @param _nftId The id of the NFT to update
@@ -117,7 +117,7 @@ interface INestedFactory {
         IERC20 _buyToken,
         uint256[] memory _sellTokensAmount,
         Order[] calldata _orders
-    ) external payable;
+    ) external;
 
     /// @notice Liquidate one or more holdings and transfer the sale amount to the user
     /// @param _nftId The id of the NFT to update
@@ -129,7 +129,7 @@ interface INestedFactory {
         IERC20 _buyToken,
         uint256[] memory _sellTokensAmount,
         Order[] calldata _orders
-    ) external payable;
+    ) external;
 
     /// @notice Burn NFT and Sell all tokens for a specific ERC20 then send it back to the user
     /// @dev Will unwrap WETH output to ETH

--- a/test/unit/NestedRecords.unit.ts
+++ b/test/unit/NestedRecords.unit.ts
@@ -53,22 +53,6 @@ describe("NestedRecords", () => {
         );
     });
 
-    it("updates a record", async () => {
-        const weth = "0xc778417E063141139Fce010982780140Aa0cD5Ab";
-        const tx = await nestedRecords.store(0, weth, appendDecimals(10), bob.address);
-        await tx.wait();
-        const tx0 = await nestedRecords.update(0, 0, weth, appendDecimals(5));
-        await tx0.wait();
-        const holding = await nestedRecords.getAssetHolding(0, weth);
-        expect(holding.amount).to.equal(appendDecimals(5));
-        const tx1 = await nestedRecords.update(0, 0, weth, appendDecimals(5));
-        await tx1.wait();
-        const tokens = await nestedRecords.getAssetTokens(0);
-        expect(tokens.length).to.equal(0);
-        const emptyHolding = await nestedRecords.getAssetHolding(0, weth);
-        expect(emptyHolding.token).to.equal(ethers.constants.AddressZero);
-    });
-
     describe("#setMaxHoldingsCount", () => {
         it("reverts when setting an incorrect number of max holdings", async () => {
             await expect(nestedRecords.setMaxHoldingsCount(0)).to.be.revertedWith(


### PR DESCRIPTION
### PVE001-3
Remove "without royalties" comment

### PVE002
Remove useless "payable"

### PVE002-2
Remove `_sellToken.approve(_swapTarget, balance);` before `fillQuote` (already doing the approve).

### Question 3 (unused functions in Records)
- Remove useless `update(...)` function (+ tests)
- `freeToken(…)` is now private (only used locally)

_Note :_ `setReserve(…)` is not removed, it can be use by a next version of the Factory.
