### PR TITLE
Peckshield PVE004

### DIFF
--- a/contracts/NestedAsset.sol
+++ b/contracts/NestedAsset.sol
@@ -76,6 +76,11 @@ contract NestedAsset is ERC721Enumerable, Ownable {
             return tokenId;
         }
 
+        require(
+            _exists(_replicatedTokenId) && tokenId != _replicatedTokenId,
+            "NestedAsset::mint: Invalid replicated token ID"
+        );
+
         uint256 originalTokenId = originalAsset[_replicatedTokenId];
         originalAsset[tokenId] = originalTokenId != 0 ? originalTokenId : _replicatedTokenId;
 

--- a/test/unit/NestedAsset.unit.ts
+++ b/test/unit/NestedAsset.unit.ts
@@ -2,6 +2,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { NestedAsset, NestedAsset__factory } from "../../typechain";
+import { BigNumber } from "ethers";
 
 describe("NestedAsset", () => {
     let NestedAsset: NestedAsset__factory, asset: NestedAsset;
@@ -54,6 +55,15 @@ describe("NestedAsset", () => {
                 expect(await asset.originalAsset(1)).to.equal(0);
                 expect(await asset.originalAsset(2)).to.equal(1);
                 expect(await asset.originalAsset(3)).to.equal(1);
+            });
+
+            it("should revert if replicate id doesnt exist", async () => {
+                await expect(asset.mint(alice.address, 1)).to.be.revertedWith(
+                    "NestedAsset::mint: Invalid replicated token ID",
+                );
+                await expect(asset.mint(alice.address, 10)).to.be.revertedWith(
+                    "NestedAsset::mint: Invalid replicated token ID",
+                );
             });
         });
 


### PR DESCRIPTION
![telegram-cloud-photo-size-5-6282781317569555813-y](https://user-images.githubusercontent.com/22816913/137162635-e85d8344-be07-40bc-b388-bdb55015e0e0.jpg)

In this PVE, we can't fully fix the issue... Because most of this issue is "by design" and accepted.

The only parts we are fixing in this PR are :
- Prevent the user from replicating a non-existent portfolio (id)
- Prevent the user from replicating the portfolio created in the same transaction.