### PR TITLE
Unlock tokens (factory)

### DIFF
--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -257,6 +257,11 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         nestedRecords.updateLockTimestamp(_nftId, _timestamp);
     }
 
+    /// @inheritdoc INestedFactory
+    function unlockTokens(IERC20 _token) external override onlyOwner {
+        _token.transfer(owner(), _token.balanceOf(address(this)));
+    }
+
     /// @dev For every orders, call the operator with the calldata
     /// to submit buy orders (where the input is one asset).
     /// @param _nftId The id of the NFT impacted by the orders

--- a/contracts/interfaces/INestedFactory.sol
+++ b/contracts/interfaces/INestedFactory.sol
@@ -127,13 +127,17 @@ interface INestedFactory {
     /// @notice Withdraw a token from the reserve and transfer it to the owner without exchanging it
     /// @param _nftId NFT token ID
     /// @param _tokenIndex Index in array of tokens for this NFT and holding.
-    function withdraw(
-        uint256 _nftId,
-        uint256 _tokenIndex
-    ) external;
+    function withdraw(uint256 _nftId, uint256 _tokenIndex) external;
 
     /// @notice Increase the lock timestamp of an NFT record.
     /// @param _nftId The NFT id to get the record
     /// @param _timestamp The new timestamp.
     function increaseLockTimestamp(uint256 _nftId, uint256 _timestamp) external;
+
+    /// @notice The Factory is not storing funds, but some users can make
+    /// bad manipulations and send tokens to the contract.
+    /// In response to that, the owner can retrieve the factory balance of a given token
+    /// to later return users funds.
+    /// @param _token The token to retrieve.
+    function unlockTokens(IERC20 _token) external;
 }

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -14,8 +14,6 @@ import {
     OperatorResolver,
     SynthetixOperator,
     TestableOperatorCaller,
-    TestableOwnableOperatorCaller,
-    TestableOwnedOperator,
     TestableSynthetix,
     WETH9,
     ZeroExOperator,


### PR DESCRIPTION
The Factory is not storing funds, but some users can make bad manipulations and send tokens to the contract.

In response to that, the owner can retrieve the factory balance of a given token with new function : `unlockTokens`

(to later return users funds)