### PR TITLE
[CodeArena] - [G-06/N-12] : Require messages shorten to fit in 32 bytes

### DIFF
--- a/contracts/FeeSplitter.sol
+++ b/contracts/FeeSplitter.sol
@@ -71,7 +71,7 @@ contract FeeSplitter is Ownable, ReentrancyGuard {
 
     /// @dev Receive ether after a WETH withdraw call
     receive() external payable {
-        require(msg.sender == weth, "FeeSplitter: ETH_SENDER_NOT_WETH");
+        require(msg.sender == weth, "FS: ETH_SENDER_NOT_WETH");
     }
 
     /// @notice Returns the amount due to an account. Call releaseToken to withdraw the amount.
@@ -101,7 +101,7 @@ contract FeeSplitter is Ownable, ReentrancyGuard {
     /// @param _weights Weight for each shareholder. Determines part of the payment allocated to them
     function setShareholders(address[] memory _accounts, uint256[] memory _weights) public onlyOwner {
         delete shareholders;
-        require(_accounts.length > 0 && _accounts.length == _weights.length, "FeeSplitter: ARRAY_LENGTHS_ERR");
+        require(_accounts.length > 0 && _accounts.length == _weights.length, "FS: INPUTS_LENGTH_MUST_MATCH");
         totalWeights = royaltiesWeight;
 
         for (uint256 i = 0; i < _accounts.length; i++) {
@@ -132,7 +132,7 @@ contract FeeSplitter is Ownable, ReentrancyGuard {
         uint256 amount = _releaseToken(_msgSender(), IERC20(weth));
         IWETH(weth).withdraw(amount);
         (bool success, ) = _msgSender().call{ value: amount }("");
-        require(success, "FeeSplitter: ETH_TRANFER_ERROR");
+        require(success, "FS: ETH_TRANFER_ERROR");
         emit PaymentReleased(_msgSender(), ETH, amount);
     }
 
@@ -153,7 +153,7 @@ contract FeeSplitter is Ownable, ReentrancyGuard {
         IERC20 _token,
         uint256 _amount
     ) external nonReentrant {
-        require(_royaltiesTarget != address(0), "FeeSplitter: INVALID_ROYALTIES_TARGET_ADDRESS");
+        require(_royaltiesTarget != address(0), "FS: INVALID_ROYALTIES_TARGET_ADDRESS");
 
         uint256 _totalWeights = totalWeights;
 
@@ -165,9 +165,9 @@ contract FeeSplitter is Ownable, ReentrancyGuard {
     /// @param _accountIndex Account to change the weight of
     /// @param _weight The new weight
     function updateShareholder(uint256 _accountIndex, uint256 _weight) external onlyOwner {
-        require(_accountIndex < shareholders.length, "FeeSplitter: INVALID_ACCOUNT_INDEX");
+        require(_accountIndex < shareholders.length, "FS: INVALID_ACCOUNT_INDEX");
         totalWeights = totalWeights + _weight - shareholders[_accountIndex].weight;
-        require(totalWeights != 0, "FeeSplitter: TOTAL_WEIGHTS_ZERO");
+        require(totalWeights != 0, "FS: TOTAL_WEIGHTS_ZERO");
         shareholders[_accountIndex].weight = _weight;
     }
 
@@ -208,7 +208,7 @@ contract FeeSplitter is Ownable, ReentrancyGuard {
         for (uint256 i = 0; i < shareholders.length; i++) {
             if (shareholders[i].account == _account) return i;
         }
-        revert("FeeSplitter: NOT_FOUND");
+        revert("FS: SHAREHOLDER_NOT_FOUND");
     }
 
     /// @dev Transfers a fee to this contract
@@ -249,7 +249,7 @@ contract FeeSplitter is Ownable, ReentrancyGuard {
     function _releaseToken(address _account, IERC20 _token) private returns (uint256) {
         TokenRecords storage _tokenRecords = tokenRecords[address(_token)];
         uint256 amountToRelease = getAmountDue(_account, _token);
-        require(amountToRelease != 0, "FeeSplitter: NO_PAYMENT_DUE");
+        require(amountToRelease != 0, "FS: NO_PAYMENT_DUE");
 
         _tokenRecords.released[_account] += amountToRelease;
         _tokenRecords.totalReleased += amountToRelease;
@@ -258,7 +258,7 @@ contract FeeSplitter is Ownable, ReentrancyGuard {
     }
 
     function _addShareholder(address _account, uint256 _weight) private {
-        require(_weight > 0, "FeeSplitter: ZERO_WEIGHT");
+        require(_weight > 0, "FS: ZERO_WEIGHT");
         shareholders.push(Shareholder(_account, _weight));
         totalWeights += _weight;
     }

--- a/contracts/MixinOperatorResolver.sol
+++ b/contracts/MixinOperatorResolver.sol
@@ -60,7 +60,7 @@ abstract contract MixinOperatorResolver {
     /// @return The operator address
     function requireAndGetAddress(bytes32 name) internal view returns (address) {
         address _foundAddress = addressCache[name];
-        require(_foundAddress != address(0), string(abi.encodePacked("Missing operator : ", name)));
+        require(_foundAddress != address(0), string(abi.encodePacked("MOR: MISSING_OPERATOR: ", name)));
         return _foundAddress;
     }
 }

--- a/contracts/NestedAsset.sol
+++ b/contracts/NestedAsset.sol
@@ -31,13 +31,13 @@ contract NestedAsset is ERC721Enumerable, Ownable {
 
     /// @dev Reverts the transaction if the caller is not the factory
     modifier onlyFactory() {
-        require(supportedFactories[msg.sender], "NestedAsset: FORBIDDEN_NOT_FACTORY");
+        require(supportedFactories[msg.sender], "NA: FORBIDDEN_NOT_FACTORY");
         _;
     }
 
     /// @dev Reverts the transaction if the address is not the token owner
     modifier onlyTokenOwner(address _address, uint256 _tokenId) {
-        require(_address == ownerOf(_tokenId), "NestedAsset: FORBIDDEN_NOT_OWNER");
+        require(_address == ownerOf(_tokenId), "NA: FORBIDDEN_NOT_OWNER");
         _;
     }
 
@@ -79,7 +79,7 @@ contract NestedAsset is ERC721Enumerable, Ownable {
 
         require(
             _exists(_replicatedTokenId) && tokenId != _replicatedTokenId,
-            "NestedAsset::mint: Invalid replicated token ID"
+            "NA: INVALID_REPLICATED_TOKEN_ID"
         );
 
         uint256 originalTokenId = originalAsset[_replicatedTokenId];
@@ -112,7 +112,7 @@ contract NestedAsset is ERC721Enumerable, Ownable {
         address _owner,
         string memory _metadataURI
     ) external onlyFactory onlyTokenOwner(_owner, _tokenId) {
-        require(bytes(tokenURI(_tokenId)).length == 0, "NestedAsset: TOKEN_URI_IMMUTABLE");
+        require(bytes(tokenURI(_tokenId)).length == 0, "NA: TOKEN_URI_IMMUTABLE");
         _setTokenURI(_tokenId, _metadataURI);
     }
 
@@ -131,7 +131,7 @@ contract NestedAsset is ERC721Enumerable, Ownable {
     /// @notice Sets the factory for Nested assets
     /// @param _factory the address of the new factory
     function setFactory(address _factory) external onlyOwner {
-        require(_factory != address(0), "NestedAsset: INVALID_ADDRESS");
+        require(_factory != address(0), "NA: INVALID_ADDRESS");
         supportedFactories[_factory] = true;
         emit FactoryAdded(_factory);
     }
@@ -139,7 +139,7 @@ contract NestedAsset is ERC721Enumerable, Ownable {
     /// @notice Remove a supported factory from NestedAssets
     /// @param _factory The address of the factory to remove
     function removeFactory(address _factory) external onlyOwner {
-        require(supportedFactories[_factory], "NestedAsset: ALREADY_NOT_SUPPORTED");
+        require(supportedFactories[_factory], "NA: ALREADY_NOT_SUPPORTED");
         supportedFactories[_factory] = false;
         emit FactoryRemoved(_factory);
     }

--- a/contracts/NestedBuybacker.sol
+++ b/contracts/NestedBuybacker.sol
@@ -49,7 +49,7 @@ contract NestedBuybacker is Ownable {
         address payable _feeSplitter,
         uint256 _burnPercentage
     ) {
-        require(_burnPercentage <= 1000, "NestedBuybacker::constructor: Burn part too high");
+        require(_burnPercentage <= 1000, "NB: INVALID_BURN_PART");
         burnPercentage = _burnPercentage;
         NST = INestedToken(_NST);
         feeSplitter = FeeSplitter(_feeSplitter);
@@ -79,7 +79,7 @@ contract NestedBuybacker is Ownable {
     /// @notice Update parts deciding what amount is sent to reserve or burned
     /// @param _burnPercentage The new burn percentage
     function setBurnPart(uint256 _burnPercentage) public onlyOwner {
-        require(_burnPercentage <= 1000, "NestedBuybacker::setBurnPart: Burn part too high");
+        require(_burnPercentage <= 1000, "NB: INVALID_BURN_PART");
         burnPercentage = _burnPercentage;
         emit BurnPartUpdated(burnPercentage);
     }

--- a/contracts/NestedRecords.sol
+++ b/contracts/NestedRecords.sol
@@ -45,7 +45,7 @@ contract NestedRecords is Ownable {
 
     /// @dev Reverts the transaction if the caller is not the factory
     modifier onlyFactory() {
-        require(supportedFactories[_msgSender()], "NestedRecords: FORBIDDEN");
+        require(supportedFactories[_msgSender()], "NRC: FORBIDDEN");
         _;
     }
 
@@ -64,14 +64,14 @@ contract NestedRecords is Ownable {
         uint256 _amount,
         address _reserve
     ) public onlyFactory {
-        require(records[_nftId].tokens.length < maxHoldingsCount, "NestedRecords: TOO_MANY_ORDERS");
+        require(records[_nftId].tokens.length < maxHoldingsCount, "NRC: TOO_MANY_ORDERS");
         require(
             _reserve != address(0) && (_reserve == records[_nftId].reserve || records[_nftId].reserve == address(0)),
-            "NestedRecords: INVALID_RESERVE"
+            "NRC: INVALID_RESERVE"
         );
 
         Holding memory holding = records[_nftId].holdings[_token];
-        require(!holding.isActive, "NestedRecords: HOLDING_EXISTS");
+        require(!holding.isActive, "NRC: HOLDING_EXISTS");
 
         records[_nftId].holdings[_token] = Holding({ token: _token, amount: _amount, isActive: true });
         records[_nftId].tokens.push(_token);
@@ -129,7 +129,7 @@ contract NestedRecords is Ownable {
     ) external onlyFactory {
         Holding memory holding = records[_nftId].holdings[_token];
         if (holding.isActive) {
-            require(records[_nftId].reserve == _reserve, "NestedRecords: RESERVE_MISMATCH");
+            require(records[_nftId].reserve == _reserve, "NRC: RESERVE_MISMATCH");
             updateHoldingAmount(_nftId, _token, holding.amount + _amount);
             return;
         }
@@ -146,7 +146,7 @@ contract NestedRecords is Ownable {
     /// @notice Sets the factory for Nested records
     /// @param _factory The address of the new factory
     function setFactory(address _factory) external onlyOwner {
-        require(_factory != address(0), "NestedRecords: INVALID_ADDRESS");
+        require(_factory != address(0), "NRC: INVALID_ADDRESS");
         supportedFactories[_factory] = true;
         emit FactoryAdded(_factory);
     }
@@ -159,7 +159,7 @@ contract NestedRecords is Ownable {
     function updateLockTimestamp(uint256 _nftId, uint256 _timestamp) external onlyFactory {
         require(
             _timestamp > records[_nftId].lockTimestamp,
-            "NestedRecords::increaseLockTimestamp: Can't decrease timestamp"
+            "NRC: LOCK_PERIOD_CANT_DECREASE"
         );
         records[_nftId].lockTimestamp = _timestamp;
         emit LockTimestampIncreased(_nftId, _timestamp);
@@ -168,7 +168,7 @@ contract NestedRecords is Ownable {
     /// @notice Sets the maximum number of holdings for an NFT record
     /// @param _maxHoldingsCount The new maximum number of holdings
     function setMaxHoldingsCount(uint256 _maxHoldingsCount) external onlyOwner {
-        require(_maxHoldingsCount > 0, "NestedRecords: INVALID_MAX_HOLDINGS");
+        require(_maxHoldingsCount > 0, "NRC: INVALID_MAX_HOLDINGS");
         maxHoldingsCount = _maxHoldingsCount;
         emit MaxHoldingsChanges(maxHoldingsCount);
     }
@@ -215,7 +215,7 @@ contract NestedRecords is Ownable {
         address token = tokens[_tokenIndex];
         Holding memory holding = records[_nftId].holdings[token];
 
-        require(holding.isActive, "NestedRecords: HOLDING_INACTIVE");
+        require(holding.isActive, "NRC: HOLDING_INACTIVE");
 
         delete records[_nftId].holdings[token];
         freeToken(_nftId, _tokenIndex);

--- a/contracts/NestedReserve.sol
+++ b/contracts/NestedReserve.sol
@@ -22,7 +22,7 @@ contract NestedReserve is Ownable {
 
     /// @dev Reverts if the caller is not the factory
     modifier onlyFactory() {
-        require(_msgSender() == factory, "NestedReserve: UNAUTHORIZED");
+        require(_msgSender() == factory, "NRS: UNAUTHORIZED");
         _;
     }
 
@@ -35,7 +35,7 @@ contract NestedReserve is Ownable {
         IERC20 _token,
         uint256 _amount
     ) external onlyFactory {
-        require(_recipient != address(0), "NestedReserve: INVALID_ADDRESS");
+        require(_recipient != address(0), "NRS: INVALID_ADDRESS");
         _token.safeTransfer(_recipient, _amount);
     }
 
@@ -49,7 +49,7 @@ contract NestedReserve is Ownable {
     /// @notice Update the factory address
     /// @param _newFactory The new factory address
     function updateFactory(address _newFactory) external onlyOwner {
-        require(_newFactory != address(0), "NestedReserve: INVALID_ADDRESS");
+        require(_newFactory != address(0), "NRS: INVALID_ADDRESS");
         factory = _newFactory;
         emit FactoryUpdated(_newFactory);
     }

--- a/contracts/OperatorResolver.sol
+++ b/contracts/OperatorResolver.sol
@@ -32,7 +32,7 @@ contract OperatorResolver is IOperatorResolver, Ownable {
     {
         require(
             names.length == destinations.length,
-            "OperatorResolver::areAddressesImported: Input lengths must match"
+            "OR: INPUTS_LENGTH_MUST_MATCH"
         );
         for (uint256 i = 0; i < names.length; i++) {
             if (operators[names[i]] != destinations[i]) {
@@ -44,7 +44,7 @@ contract OperatorResolver is IOperatorResolver, Ownable {
 
     /// @inheritdoc IOperatorResolver
     function importOperators(bytes32[] calldata names, address[] calldata destinations) external override onlyOwner {
-        require(names.length == destinations.length, "OperatorResolver::importOperators: Input lengths must match");
+        require(names.length == destinations.length, "OR: INPUTS_LENGTH_MUST_MATCH");
 
         for (uint256 i = 0; i < names.length; i++) {
             bytes32 name = names[i];

--- a/contracts/libraries/OperatorHelpers.sol
+++ b/contracts/libraries/OperatorHelpers.sol
@@ -48,7 +48,7 @@ library OperatorHelpers {
         address _outputToken
     ) internal returns (uint256[] memory amounts, address[] memory tokens) {
         (amounts, tokens) = abi.decode(_data, (uint256[], address[]));
-        require(tokens[0] == _outputToken, "OperatorHelpers::decodeDataAndRequire: Wrong output token");
-        require(tokens[1] == _inputToken, "OperatorHelpers::decodeDataAndRequire: Wrong input token");
+        require(tokens[0] == _outputToken, "OH: INVALID_OUTPUT_TOKEN");
+        require(tokens[1] == _inputToken, "OH: INVALID_OUTPUT_TOKEN");
     }
 }

--- a/contracts/operators/Flat/FlatOperator.sol
+++ b/contracts/operators/Flat/FlatOperator.sol
@@ -15,7 +15,7 @@ contract FlatOperator is IFlatOperator, IOperatorSelector {
         address token,
         uint256 amount
     ) external payable override returns (uint256[] memory amounts, address[] memory tokens) {
-        require(amount > 0, "FlatOperator::commitAndRevert: Amount must be greater than zero");
+        require(amount > 0, "FO: INVALID_AMOUNT");
 
         amounts = new uint256[](2);
         tokens = new address[](2);

--- a/contracts/operators/Flat/README.md
+++ b/contracts/operators/Flat/README.md
@@ -21,7 +21,7 @@ function commitAndRevert(
     address token,
     uint256 amount
 ) external payable override returns (uint256[] memory amounts, address[] memory tokens) {
-    require(amount > 0, "FlatOperator::commitAndRevert: Amount must be greater than zero");
+    require(amount > 0, "FO: INVALID_AMOUNT");
 
     amounts = new uint256[](2);
     tokens = new address[](2);

--- a/contracts/operators/ZeroEx/ZeroExOperator.sol
+++ b/contracts/operators/ZeroEx/ZeroExOperator.sol
@@ -34,7 +34,7 @@ contract ZeroExOperator is IZeroExOperator, IOperatorSelector {
             ZeroExStorage(storageAddress(self)).swapTarget(),
             swapCallData
         );
-        require(success, "ZeroExOperator::commitAndRevert: 0x swap failed");
+        require(success, "ZEO: SWAP_FAILED");
 
         uint256 amountBought = buyToken.balanceOf(address(this)) - buyBalanceBeforePurchase;
         uint256 amountSold = sellBalanceBeforePurchase - sellToken.balanceOf(address(this));

--- a/test/unit/FeeSplitter.unit.ts
+++ b/test/unit/FeeSplitter.unit.ts
@@ -51,12 +51,12 @@ describe("Fee Splitter", () => {
     });
 
     it("should revert when calling findShareholder", async () => {
-        await expect(feeSplitter.findShareholder(feeSplitter.address)).to.be.revertedWith("FeeSplitter: NOT_FOUND");
+        await expect(feeSplitter.findShareholder(feeSplitter.address)).to.be.revertedWith("FS: SHAREHOLDER_NOT_FOUND");
     });
 
     it("should revert when calling setShareholders", async () => {
         await expect(feeSplitter.setShareholders([alice.address, bob.address], [100])).to.be.revertedWith(
-            "FeeSplitter: ARRAY_LENGTHS_ERR",
+            "FS: INPUTS_LENGTH_MUST_MATCH",
         );
     });
 
@@ -66,7 +66,7 @@ describe("Fee Splitter", () => {
                 to: feeSplitter.address,
                 value: 1,
             }),
-        ).to.be.revertedWith("FeeSplitter: ETH_SENDER_NOT_WETH");
+        ).to.be.revertedWith("FS: ETH_SENDER_NOT_WETH");
     });
 
     it("releases fees as ETH", async () => {
@@ -89,7 +89,7 @@ describe("Fee Splitter", () => {
         it("should revert because no payment is due", async () => {
             const token = ERC20Mocks[0];
             const release = () => feeSplitter.connect(bob).releaseToken(token.address);
-            await expect(release()).to.be.revertedWith("FeeSplitter: NO_PAYMENT_DUE");
+            await expect(release()).to.be.revertedWith("FS: NO_PAYMENT_DUE");
         });
 
         it("retrieves split token fees", async () => {
@@ -144,18 +144,18 @@ describe("Fee Splitter", () => {
         it("should revert because sum of weights is zero", async () => {
             await feeSplitter.setRoyaltiesWeight(0);
             await feeSplitter.updateShareholder(0, 0);
-            await expect(feeSplitter.updateShareholder(1, 0)).to.be.revertedWith("FeeSplitter: TOTAL_WEIGHTS_ZERO");
+            await expect(feeSplitter.updateShareholder(1, 0)).to.be.revertedWith("FS: TOTAL_WEIGHTS_ZERO");
         });
 
         it("should revert when adding a shareholder with a weight of zero", async () => {
             await expect(feeSplitter.setShareholders([bob.address], [0])).to.be.revertedWith(
-                "FeeSplitter: ZERO_WEIGHT",
+                "FS: ZERO_WEIGHT",
             );
         });
 
         it("should revert if account index invalid", async () => {
             await expect(feeSplitter.updateShareholder(10, 10)).to.be.revertedWith(
-                "FeeSplitter: INVALID_ACCOUNT_INDEX",
+                "FS: INVALID_ACCOUNT_INDEX",
             );
         });
 

--- a/test/unit/FlatOperator.unit.ts
+++ b/test/unit/FlatOperator.unit.ts
@@ -48,7 +48,7 @@ describe("FlatOperator", () => {
 
         await expect(
             context.nestedFactory.connect(context.user1).create(0, context.mockUNI.address, totalToSpend, orders),
-        ).to.revertedWith("NestedFactory::_submitOrder: Operator call failed");
+        ).to.revertedWith("NF: OPERATOR_CALL_FAILED");
     });
 
     it("Cant use with different input", async () => {
@@ -69,7 +69,7 @@ describe("FlatOperator", () => {
 
         await expect(
             context.nestedFactory.connect(context.user1).create(0, context.mockUNI.address, totalToSpend, orders),
-        ).to.revertedWith("OperatorHelpers::decodeDataAndRequire: Wrong output token");
+        ).to.revertedWith("OH: INVALID_OUTPUT_TOKEN");
     });
 
     it("Adds token to portfolio when create()", async () => {

--- a/test/unit/NestedAsset.unit.ts
+++ b/test/unit/NestedAsset.unit.ts
@@ -59,10 +59,10 @@ describe("NestedAsset", () => {
 
             it("should revert if replicate id doesnt exist", async () => {
                 await expect(asset.mint(alice.address, 1)).to.be.revertedWith(
-                    "NestedAsset::mint: Invalid replicated token ID",
+                    "NA: INVALID_REPLICATED_TOKEN_ID",
                 );
                 await expect(asset.mint(alice.address, 10)).to.be.revertedWith(
-                    "NestedAsset::mint: Invalid replicated token ID",
+                    "NA: INVALID_REPLICATED_TOKEN_ID",
                 );
             });
         });
@@ -70,7 +70,7 @@ describe("NestedAsset", () => {
         it("should revert if the caller is not the factory", async () => {
             // Alice tries to mint a token for herself and bypass the factory
             await expect(asset.connect(alice).mint(alice.address, 0)).to.be.revertedWith(
-                "NestedAsset: FORBIDDEN_NOT_FACTORY",
+                "NA: FORBIDDEN_NOT_FACTORY",
             );
         });
     });
@@ -111,7 +111,7 @@ describe("NestedAsset", () => {
         it("should revert if the caller is not the factory", async () => {
             // Alice tries to burn the token herself and bypass the factory
             await expect(asset.connect(alice).burn(alice.address, 1)).to.be.revertedWith(
-                "NestedAsset: FORBIDDEN_NOT_FACTORY",
+                "NA: FORBIDDEN_NOT_FACTORY",
             );
         });
 
@@ -119,7 +119,7 @@ describe("NestedAsset", () => {
             await asset.mint(bob.address, 0);
 
             // Alice asked to burn Bob's token
-            await expect(asset.burn(alice.address, 1)).to.be.revertedWith("NestedAsset: FORBIDDEN_NOT_OWNER");
+            await expect(asset.burn(alice.address, 1)).to.be.revertedWith("NA: FORBIDDEN_NOT_OWNER");
         });
     });
 
@@ -131,19 +131,19 @@ describe("NestedAsset", () => {
         it("should revert the URI is already set", async () => {
             await asset.backfillTokenURI(1, bob.address, "ipfs://tokenURI");
             await expect(asset.backfillTokenURI(1, bob.address, "ipfs://newTokenURI")).to.be.revertedWith(
-                "NestedAsset: TOKEN_URI_IMMUTABLE",
+                "NA: TOKEN_URI_IMMUTABLE",
             );
         });
 
         it("should revert if the caller is not the factory", async () => {
             await expect(asset.connect(bob).backfillTokenURI(1, bob.address, "ipfs://newTokenURI")).to.be.revertedWith(
-                "NestedAsset: FORBIDDEN_NOT_FACTORY",
+                "NA: FORBIDDEN_NOT_FACTORY",
             );
         });
 
         it("should revert if the token does not belong to the owner", async () => {
             await expect(asset.backfillTokenURI(1, alice.address, "ipfs://newTokenURI")).to.be.revertedWith(
-                "NestedAsset: FORBIDDEN_NOT_OWNER",
+                "NA: FORBIDDEN_NOT_OWNER",
             );
         });
 
@@ -187,7 +187,7 @@ describe("NestedAsset", () => {
 
         it("reverts if the address is invalid", async () => {
             await expect(asset.setFactory("0x0000000000000000000000000000000000000000")).to.be.revertedWith(
-                "NestedAsset: INVALID_ADDRESS",
+                "NA: INVALID_ADDRESS",
             );
             expect(await asset.supportedFactories(otherFactory.address)).to.equal(false);
         });
@@ -213,11 +213,11 @@ describe("NestedAsset", () => {
 
         it("reverts if already not supported", async () => {
             await expect(asset.removeFactory(otherFactory.address)).to.be.revertedWith(
-                "NestedAsset: ALREADY_NOT_SUPPORTED",
+                "NA: ALREADY_NOT_SUPPORTED",
             );
 
             await expect(asset.removeFactory(ethers.constants.AddressZero)).to.be.revertedWith(
-                "NestedAsset: ALREADY_NOT_SUPPORTED",
+                "NA: ALREADY_NOT_SUPPORTED",
             );
         });
     });

--- a/test/unit/NestedBuyBacker.unit.ts
+++ b/test/unit/NestedBuyBacker.unit.ts
@@ -45,11 +45,11 @@ describe("NestedBuybacker", () => {
         dummyRouter = await DummyRouterFactory.deploy();
     });
 
-    it("should revert with BURN_PART_TOO_HIGH", async () => {
+    it("should revert with INVALID_BURN_PART", async () => {
         const NestedBuybackerFactory = await ethers.getContractFactory("NestedBuybacker");
         await expect(
             NestedBuybackerFactory.deploy(mockNST.address, communityReserve.address, feeSplitter.address, 1200),
-        ).to.be.revertedWith("NestedBuybacker::constructor: Burn part too high");
+        ).to.be.revertedWith("NB: INVALID_BURN_PART");
     });
 
     it("sets the nested reserve address", async () => {

--- a/test/unit/NestedFactory.unit.ts
+++ b/test/unit/NestedFactory.unit.ts
@@ -143,7 +143,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .create(0, context.mockDAI.address, appendDecimals(5), orders),
-            ).to.be.revertedWith("Missing operator : test");
+            ).to.be.revertedWith("MOR: MISSING_OPERATOR: test");
         });
     });
 
@@ -159,7 +159,7 @@ describe("NestedFactory", () => {
             await context.nestedFactory.connect(context.masterDeployer).setReserve(context.nestedReserve.address);
             await expect(
                 context.nestedFactory.connect(context.masterDeployer).setReserve(newReserve),
-            ).to.be.revertedWith("NestedFactory::setReserve: Reserve is immutable");
+            ).to.be.revertedWith("NF: RESERVE_ADDRESS_IMMUTABLE");
         });
 
         it("set value", async () => {
@@ -185,7 +185,7 @@ describe("NestedFactory", () => {
         it("cant set zero address", async () => {
             await expect(
                 context.nestedFactory.connect(context.masterDeployer).setFeeSplitter(ethers.constants.AddressZero),
-            ).to.be.revertedWith("NestedFactory::setFeeSplitter: Invalid feeSplitter address");
+            ).to.be.revertedWith("NF: INVALID_FEE_SPLITTER_ADDRESS");
         });
 
         it("set value", async () => {
@@ -209,7 +209,7 @@ describe("NestedFactory", () => {
             let orders: OrderStruct[] = [];
             await expect(
                 context.nestedFactory.connect(context.user1).create(0, context.mockDAI.address, 0, orders),
-            ).to.be.revertedWith("NestedFactory::create: Missing orders");
+            ).to.be.revertedWith("NF: INVALID_ORDERS");
         });
 
         it("reverts if bad calldatas", async () => {
@@ -237,7 +237,7 @@ describe("NestedFactory", () => {
 
             await expect(
                 context.nestedFactory.connect(context.user1).create(0, context.mockDAI.address, totalToSpend, orders),
-            ).to.be.revertedWith("NestedFactory::_submitOrder: Operator call failed");
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
         it("reverts if wrong output token in calldata", async () => {
@@ -266,7 +266,7 @@ describe("NestedFactory", () => {
 
             await expect(
                 context.nestedFactory.connect(context.user1).create(0, context.mockDAI.address, totalToSpend, orders),
-            ).to.be.revertedWith("OperatorHelpers::decodeDataAndRequire: Wrong output token");
+            ).to.be.revertedWith("OH: INVALID_OUTPUT_TOKEN");
         });
 
         it("reverts if the DAI amount is less than total sum of DAI sales", async () => {
@@ -285,7 +285,7 @@ describe("NestedFactory", () => {
             // Revert because not enough funds to swap, the order amounts > totalToSpend
             await expect(
                 context.nestedFactory.connect(context.user1).create(0, context.mockDAI.address, totalToSpend, orders),
-            ).to.be.revertedWith("NestedFactory::_submitOrder: Operator call failed");
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
         it("reverts if not enough to pay fees", async () => {
@@ -543,7 +543,7 @@ describe("NestedFactory", () => {
             let orders: OrderStruct[] = [];
             await expect(
                 context.nestedFactory.connect(context.user1).addTokens(1, context.mockDAI.address, 0, orders),
-            ).to.be.revertedWith("NestedFactory::addTokens: Missing orders");
+            ).to.be.revertedWith("NF: INVALID_ORDERS");
         });
 
         it("reverts if bad calldatas", async () => {
@@ -573,7 +573,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .addTokens(1, context.mockDAI.address, totalToSpend, orders),
-            ).to.be.revertedWith("NestedFactory::_submitOrder: Operator call failed");
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
         it("cant add tokens to nonexistent portfolio", async () => {
@@ -607,7 +607,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.masterDeployer)
                     .addTokens(1, context.mockDAI.address, totalToSpend, orders),
-            ).to.be.revertedWith("NestedFactory: Not the token owner");
+            ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
         it("reverts if wrong output token in calldata", async () => {
@@ -638,7 +638,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .addTokens(1, context.mockDAI.address, totalToSpend, orders),
-            ).to.be.revertedWith("OperatorHelpers::decodeDataAndRequire: Wrong output token");
+            ).to.be.revertedWith("OH: INVALID_OUTPUT_TOKEN");
         });
 
         it("reverts if the DAI amount is less than total sum of DAI sales", async () => {
@@ -863,7 +863,7 @@ describe("NestedFactory", () => {
                     context.nestedFactory
                         .connect(context.user1)
                         .swapTokenForTokens(1, context.mockUNI.address, 0, orders),
-                ).to.be.revertedWith("NestedFactory::addTokens: Missing orders");
+                ).to.be.revertedWith("NF: INVALID_ORDERS");
             });
         });
 
@@ -895,7 +895,7 @@ describe("NestedFactory", () => {
                     context.nestedFactory
                         .connect(context.user1)
                         .swapTokenForTokens(1, context.mockUNI.address, totalToSpend, orders),
-                ).to.be.revertedWith("NestedFactory::_submitOrder: Operator call failed");
+                ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
             });
         });
 
@@ -936,7 +936,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.masterDeployer)
                     .swapTokenForTokens(1, context.mockDAI.address, totalToSpend, orders),
-            ).to.be.revertedWith("NestedFactory: Not the token owner");
+            ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
         it("reverts if the UNI amount in portfolio is less than total sum of UNI sales", async () => {
@@ -981,7 +981,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .swapTokenForTokens(1, context.mockUNI.address, totalToSpend, orders),
-            ).to.be.revertedWith("NestedFactory:_transferInputTokens: Insufficient amount");
+            ).to.be.revertedWith("NF: INSUFFICIENT_AMOUNT_IN");
         });
 
         it("increase UNI amount from KNC in portfolio (ZeroExOperator) with right amounts", async () => {
@@ -1135,7 +1135,7 @@ describe("NestedFactory", () => {
             let orders: OrderStruct[] = [];
             await expect(
                 context.nestedFactory.connect(context.user1).sellTokensToNft(1, context.mockDAI.address, [], orders),
-            ).to.be.revertedWith("NestedFactory::sellTokensToNft: Missing orders");
+            ).to.be.revertedWith("NF: INVALID_ORDERS");
         });
 
         it("reverts if bad calldatas", async () => {
@@ -1163,7 +1163,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .sellTokensToNft(1, context.mockUSDC.address, [uniSold], orders),
-            ).to.be.revertedWith("NestedFactory::_submitOrder: Operator call failed");
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
         it("cant swap tokens from nonexistent portfolio", async () => {
@@ -1193,7 +1193,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.masterDeployer)
                     .sellTokensToNft(1, context.mockUSDC.address, [uniSold, kncSold], orders),
-            ).to.be.revertedWith("NestedFactory: Not the token owner");
+            ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
         it("cant swap tokens if orders dont match sell amounts (array size)", async () => {
@@ -1207,7 +1207,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .sellTokensToNft(1, context.mockUSDC.address, [uniSold], orders),
-            ).to.be.revertedWith("NestedFactory::sellTokensToNft: Input lengths must match");
+            ).to.be.revertedWith("NF: INPUTS_LENGTH_MUST_MATCH");
         });
 
         it("revert if spend more UNI than in reserve", async () => {
@@ -1221,7 +1221,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .sellTokensToNft(1, context.mockUSDC.address, [uniSold, kncSold], orders),
-            ).to.be.revertedWith("NestedFactory:_transferInputTokens: Insufficient amount");
+            ).to.be.revertedWith("NF: INSUFFICIENT_AMOUNT_IN");
         });
 
         it("revert if try to sell more KNC than sell amount", async () => {
@@ -1237,7 +1237,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .sellTokensToNft(1, context.mockUSDC.address, [uniSold, kncSold], orders),
-            ).to.be.revertedWith("NestedFactory::_submitOrder: Operator call failed");
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
         it("reverts if wrong output token in calldata", async () => {
@@ -1253,7 +1253,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .sellTokensToNft(1, context.mockDAI.address, [uniSold, kncSold], orders),
-            ).to.be.revertedWith("OperatorHelpers::decodeDataAndRequire: Wrong output token");
+            ).to.be.revertedWith("OH: INVALID_OUTPUT_TOKEN");
         });
 
         it("swap KNC and UNI for USDC (ZeroExOperator) with right amounts", async () => {
@@ -1414,7 +1414,7 @@ describe("NestedFactory", () => {
             let orders: OrderStruct[] = [];
             await expect(
                 context.nestedFactory.connect(context.user1).sellTokensToWallet(1, context.mockDAI.address, [], orders),
-            ).to.be.revertedWith("NestedFactory::sellTokensToWallet: Missing orders");
+            ).to.be.revertedWith("NF: INVALID_ORDERS");
         });
 
         it("reverts if bad calldatas", async () => {
@@ -1442,7 +1442,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .sellTokensToWallet(1, context.mockUSDC.address, [uniSold], orders),
-            ).to.be.revertedWith("NestedFactory::_submitOrder: Operator call failed");
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
         it("cant swap tokens from nonexistent portfolio", async () => {
@@ -1472,7 +1472,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.masterDeployer)
                     .sellTokensToWallet(1, context.mockUSDC.address, [uniSold, kncSold], orders),
-            ).to.be.revertedWith("NestedFactory: Not the token owner");
+            ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
         it("cant swap tokens if orders dont match sell amounts (array size)", async () => {
@@ -1486,7 +1486,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .sellTokensToWallet(1, context.mockUSDC.address, [uniSold], orders),
-            ).to.be.revertedWith("NestedFactory::sellTokensToWallet: Input lengths must match");
+            ).to.be.revertedWith("NF: INPUTS_LENGTH_MUST_MATCH");
         });
 
         it("revert if spend more UNI than in reserve", async () => {
@@ -1500,7 +1500,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .sellTokensToWallet(1, context.mockUSDC.address, [uniSold, kncSold], orders),
-            ).to.be.revertedWith("NestedFactory:_transferInputTokens: Insufficient amount");
+            ).to.be.revertedWith("NF: INSUFFICIENT_AMOUNT_IN");
         });
 
         it("revert if try to sell more KNC than sell amount", async () => {
@@ -1516,7 +1516,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .sellTokensToWallet(1, context.mockUSDC.address, [uniSold, kncSold], orders),
-            ).to.be.revertedWith("NestedFactory::_submitOrder: Operator call failed");
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
         it("reverts if wrong output token in calldata", async () => {
@@ -1532,7 +1532,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .sellTokensToWallet(1, context.mockDAI.address, [uniSold, kncSold], orders),
-            ).to.be.revertedWith("OperatorHelpers::decodeDataAndRequire: Wrong output token");
+            ).to.be.revertedWith("OH: INVALID_OUTPUT_TOKEN");
         });
 
         it("swap KNC and UNI for USDC (ZeroExOperator) with right amounts", async () => {
@@ -1682,7 +1682,7 @@ describe("NestedFactory", () => {
             let orders: OrderStruct[] = [];
             await expect(
                 context.nestedFactory.connect(context.user1).destroy(1, context.mockDAI.address, orders),
-            ).to.be.revertedWith("NestedFactory::destroy: Missing orders");
+            ).to.be.revertedWith("NF: INVALID_ORDERS");
         });
 
         it("doesnt revert if bad calldatas (safe destroy)", async () => {
@@ -1746,7 +1746,7 @@ describe("NestedFactory", () => {
             // Master Deployer is not the owner of NFT 1
             await expect(
                 context.nestedFactory.connect(context.masterDeployer).destroy(1, context.mockUSDC.address, orders),
-            ).to.be.revertedWith("NestedFactory: Not the token owner");
+            ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
         it("revert if holdings and orders don't match", async () => {
@@ -1772,7 +1772,7 @@ describe("NestedFactory", () => {
 
             await expect(
                 context.nestedFactory.connect(context.user1).destroy(1, context.mockUSDC.address, orders),
-            ).to.be.revertedWith("NestedFactory::destroy: Missing sell args");
+            ).to.be.revertedWith("NF: INPUTS_LENGTH_MUST_MATCH");
         });
 
         it("doesnt revert if spend more UNI than in reserve and withdraw (safe destroy)", async () => {
@@ -1914,7 +1914,7 @@ describe("NestedFactory", () => {
 
         it("cant withdraw from another user portfolio", async () => {
             await expect(context.nestedFactory.connect(context.masterDeployer).withdraw(1, 1)).to.be.revertedWith(
-                "NestedFactory: Not the token owner",
+                "NF: CALLER_NOT_OWNER",
             );
         });
 
@@ -1927,7 +1927,7 @@ describe("NestedFactory", () => {
         it("cant withdraw if wrong token index", async () => {
             // KNC => Index 1
             await expect(context.nestedFactory.connect(context.user1).withdraw(1, 2)).to.be.revertedWith(
-                "NestedFactory::withdraw: Invalid token index",
+                "NF: INVALID_TOKEN_INDEX",
             );
         });
 
@@ -1956,7 +1956,7 @@ describe("NestedFactory", () => {
 
             // Should not me able to withdraw UNI (the last token)
             await expect(context.nestedFactory.connect(context.user1).withdraw(1, 0)).to.be.revertedWith(
-                "NestedFactory::withdraw: Can't withdraw the last asset",
+                "NF: UNALLOWED_EMPTY_PORTFOLIO",
             );
         });
     });
@@ -1983,7 +1983,7 @@ describe("NestedFactory", () => {
         it("cant increase if another user portfolio", async () => {
             await expect(
                 context.nestedFactory.connect(context.masterDeployer).increaseLockTimestamp(1, Date.now()),
-            ).to.be.revertedWith("NestedFactory: Not the token owner");
+            ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
         it("cant increase nonexistent portfolio", async () => {
@@ -1996,7 +1996,7 @@ describe("NestedFactory", () => {
             await context.nestedFactory.connect(context.user1).increaseLockTimestamp(1, Date.now());
             await expect(
                 context.nestedFactory.connect(context.user1).increaseLockTimestamp(1, Date.now() - 1000),
-            ).to.be.revertedWith("NestedRecords::increaseLockTimestamp: Can't decrease timestamp");
+            ).to.be.revertedWith("NRC: LOCK_PERIOD_CANT_DECREASE");
         });
 
         /*
@@ -2009,7 +2009,7 @@ describe("NestedFactory", () => {
                 .withArgs(1, Date.now() + 1000);
 
             await expect(context.nestedFactory.connect(context.user1).withdraw(1, 0)).to.be.revertedWith(
-                "NestedFactory: The NFT is currently locked",
+                "NF: LOCKED_NFT",
             );
         });
 

--- a/test/unit/NestedRecords.unit.ts
+++ b/test/unit/NestedRecords.unit.ts
@@ -22,23 +22,23 @@ describe("NestedRecords", () => {
 
     it("reverts when setting invalid factory", async () => {
         await expect(nestedRecords.setFactory(ethers.constants.AddressZero)).to.be.revertedWith(
-            "NestedRecords: INVALID_ADDRESS",
+            "NRC: INVALID_ADDRESS",
         );
     });
 
     it("reverts when calling a factory only function when not a factory", async () => {
         await expect(nestedRecords.connect(bob).setReserve(0, bob.address)).to.be.revertedWith(
-            "NestedRecords: FORBIDDEN",
+            "NRC: FORBIDDEN",
         );
     });
 
     it("reverts when setting a wrong reserve to a NFT", async () => {
         await expect(nestedRecords.store(0, bob.address, 20, ethers.constants.AddressZero)).to.be.revertedWith(
-            "NestedRecords: INVALID_RESERVE",
+            "NRC: INVALID_RESERVE",
         );
         await nestedRecords.store(0, bob.address, 20, alice.address);
         await expect(nestedRecords.store(0, bob.address, 20, bob.address)).to.be.revertedWith(
-            "NestedRecords: RESERVE_MISMATCH",
+            "NRC: RESERVE_MISMATCH",
         );
     });
 
@@ -49,14 +49,14 @@ describe("NestedRecords", () => {
             await nestedRecords.store(0, signers[i + 3].address, 20, alice.address);
         }
         await expect(nestedRecords.store(0, bob.address, 20, alice.address)).to.be.revertedWith(
-            "NestedRecords: TOO_MANY_ORDERS",
+            "NRC: TOO_MANY_ORDERS",
         );
     });
 
     describe("#setMaxHoldingsCount", () => {
         it("reverts when setting an incorrect number of max holdings", async () => {
             await expect(nestedRecords.setMaxHoldingsCount(0)).to.be.revertedWith(
-                "NestedRecords: INVALID_MAX_HOLDINGS",
+                "NRC: INVALID_MAX_HOLDINGS",
             );
         });
 

--- a/test/unit/NestedReserve.unit.ts
+++ b/test/unit/NestedReserve.unit.ts
@@ -47,7 +47,7 @@ describe("NestedReserve", () => {
 
         it("should revert if sets the factory with address zero", async () => {
             await expect(reserve.updateFactory(ethers.constants.AddressZero)).to.be.revertedWith(
-                "NestedReserve: INVALID_ADDRESS",
+                "NRS: INVALID_ADDRESS",
             );
         });
     });
@@ -67,7 +67,7 @@ describe("NestedReserve", () => {
         it("reverts if the recipient if unauthorized", async () => {
             await expect(
                 reserve.connect(alice).transfer(alice.address, mockUNI.address, amountToTransfer),
-            ).to.be.revertedWith("NestedReserve: UNAUTHORIZED");
+            ).to.be.revertedWith("NRS: UNAUTHORIZED");
         });
 
         it("reverts if the token is invalid", async () => {
@@ -79,7 +79,7 @@ describe("NestedReserve", () => {
         it("reverts if the recipient is invalid", async () => {
             await expect(
                 reserve.transfer("0x0000000000000000000000000000000000000000", mockUNI.address, amountToTransfer),
-            ).to.be.revertedWith("NestedReserve: INVALID_ADDRESS");
+            ).to.be.revertedWith("NRS: INVALID_ADDRESS");
         });
     });
 
@@ -97,7 +97,7 @@ describe("NestedReserve", () => {
 
         it("reverts if the recipient if unauthorized", async () => {
             await expect(reserve.connect(alice).withdraw(mockUNI.address, amountToTransfer)).to.be.revertedWith(
-                "NestedReserve: UNAUTHORIZED",
+                "NRS: UNAUTHORIZED",
             );
         });
 

--- a/test/unit/OperatorResolver.unit.ts
+++ b/test/unit/OperatorResolver.unit.ts
@@ -50,7 +50,7 @@ describe("OperatorResolver", () => {
 
         describe("when a different number of names are given to addresses", () => {
             it("then it reverts", async () => {
-                const revertReason: string = "OperatorResolver::importOperators: Input lengths must match";
+                const revertReason: string = "OR: INPUTS_LENGTH_MUST_MATCH";
                 await expect(
                     context.operatorResolver
                         .connect(actors.addressResolverOwner())


### PR DESCRIPTION
I found that there is no advantage to using less than 32 bytes for a require reason, but using more will cost an extra 32 at once.

I've looked at 3 options:
1. shorten all the require messages to make them fit in 32 bytes
2. use codes to  describe errors, and have an index in the doc / or comments in natspec
3. use `CustomError`

-> I've chosen option 1. By using initials instead of contract names, and rewriting some messages, the data now fit in 32 bytes.

- 1 vs 2: Error messages are explicit enough, we can add documentation or natspec comments if needed but there is no point to name an error FS004 like we mentioned as this will take as much gas as naming it with an explicit name
- 1 vs 3: Using CustomError is more gas efficient, as we can use codes to make the string fit in 4 bytes. Although this require us to declare every single error possible in the code, and add conditions to throw the errors. IMO the code becomes less readable.

Issues => 
- https://github.com/code-423n4/2021-11-nested-findings/issues/14
- https://github.com/code-423n4/2021-11-nested-findings/issues/53