### PR TITLE
[CodeArena] - [L-05] : safeApprove shouldn't be used

### DIFF
--- a/contracts/libraries/ExchangeHelpers.sol
+++ b/contracts/libraries/ExchangeHelpers.sol
@@ -33,12 +33,10 @@ library ExchangeHelpers {
      */
     function setMaxAllowance(IERC20 _token, address _spender) internal {
         uint256 _currentAllowance = _token.allowance(address(this), _spender);
-        if (_currentAllowance == 0) {
-            _token.safeApprove(_spender, type(uint256).max);
-        } else if (_currentAllowance != type(uint256).max) {
-            // Approve 0 first for tokens mitigating the race condition
-            _token.safeApprove(_spender, 0);
-            _token.safeApprove(_spender, type(uint256).max);
+        if (_currentAllowance != type(uint256).max) {
+            // Decrease to 0 first for tokens mitigating the race condition
+            _token.safeDecreaseAllowance(_spender, _currentAllowance);
+            _token.safeIncreaseAllowance(_spender, type(uint256).max);
         }
     }
 }


### PR DESCRIPTION
Issue => https://github.com/code-423n4/2021-11-nested-findings/issues/50

I removed the `if (_currentAllowance == 0)` condition, it saves gas (on average).