### PR TITLE
[CodeArena] - [L-01/N-18/L-20] : Remove 1:1 linkage between factory & reserve

### DIFF
--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -28,8 +28,7 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
     FeeSplitter public feeSplitter;
 
     /// @dev Current reserve contract/address
-    NestedReserve public reserve;
-
+    NestedReserve public immutable reserve;
     NestedAsset public immutable nestedAsset;
     IWETH public immutable weth;
     NestedRecords public immutable nestedRecords;
@@ -37,6 +36,7 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
     constructor(
         NestedAsset _nestedAsset,
         NestedRecords _nestedRecords,
+        NestedReserve _reserve,
         FeeSplitter _feeSplitter,
         IWETH _weth,
         address _operatorResolver
@@ -44,6 +44,7 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         require(
             address(_nestedAsset) != address(0) &&
                 address(_nestedRecords) != address(0) &&
+                address(_reserve) != address(0) &&
                 address(_feeSplitter) != address(0) &&
                 address(_weth) != address(0) &&
                 _operatorResolver != address(0),
@@ -51,6 +52,7 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         );
         nestedAsset = _nestedAsset;
         nestedRecords = _nestedRecords;
+        reserve = _reserve;
         feeSplitter = _feeSplitter;
         weth = _weth;
     }
@@ -91,13 +93,6 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         }
         require(i > 0, "NF: NON_EXISTENT_OPERATOR");
         delete operators[i];
-    }
-
-    /// @inheritdoc INestedFactory
-    function setReserve(NestedReserve _reserve) external override onlyOwner {
-        require(address(reserve) == address(0), "NF: RESERVE_ADDRESS_IMMUTABLE");
-        reserve = _reserve;
-        emit ReserveUpdated(address(_reserve));
     }
 
     /// @inheritdoc INestedFactory

--- a/contracts/NestedRecords.sol
+++ b/contracts/NestedRecords.sol
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.9;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "./abstracts/OwnableFactoryHandler.sol";
 
 /// @title Tracks data for underlying assets of NestedNFTs
-contract NestedRecords is Ownable {
-    /// @dev Emitted when a new factory is added to the supported list
-    /// @param newFactory The new added factory
-    event FactoryAdded(address newFactory);
-
+contract NestedRecords is OwnableFactoryHandler {
     /// @dev Emitted when maxHoldingsCount is updated
     /// @param maxHoldingsCount The new value
     event MaxHoldingsChanges(uint256 maxHoldingsCount);
@@ -33,21 +29,11 @@ contract NestedRecords is Ownable {
         uint256 lockTimestamp;
     }
 
-    /// @dev List of supported factories.
-    /// This information is used across the protocol
-    mapping(address => bool) public supportedFactories;
-
     /// @dev stores for each NFT ID an asset record
     mapping(uint256 => NftRecord) public records;
 
     /// @dev The maximum number of holdings for an NFT record
     uint256 public maxHoldingsCount;
-
-    /// @dev Reverts the transaction if the caller is not the factory
-    modifier onlyFactory() {
-        require(supportedFactories[_msgSender()], "NRC: FORBIDDEN");
-        _;
-    }
 
     constructor(uint256 _maxHoldingsCount) {
         maxHoldingsCount = _maxHoldingsCount;
@@ -141,14 +127,6 @@ contract NestedRecords is Ownable {
     /// @param _token The address of the token
     function getAssetHolding(uint256 _nftId, address _token) external view returns (Holding memory) {
         return records[_nftId].holdings[_token];
-    }
-
-    /// @notice Sets the factory for Nested records
-    /// @param _factory The address of the new factory
-    function setFactory(address _factory) external onlyOwner {
-        require(_factory != address(0), "NRC: INVALID_ADDRESS");
-        supportedFactories[_factory] = true;
-        emit FactoryAdded(_factory);
     }
 
     /// @notice The factory can update the lock timestamp of a NFT record

--- a/contracts/NestedReserve.sol
+++ b/contracts/NestedReserve.sol
@@ -2,30 +2,13 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "./abstracts/OwnableFactoryHandler.sol";
 
 /// @title Stores underlying assets of NestedNFTs.
 /// @notice The factory itself can only trigger a transfer after verification that the user
 ///         holds funds present in this contract. Only the factory can withdraw assets.
-contract NestedReserve is Ownable {
+contract NestedReserve is OwnableFactoryHandler {
     using SafeERC20 for IERC20;
-
-    /// @dev The current factory address
-    address public factory;
-
-    /// @dev Emitted when the factory address is updated by the owner
-    event FactoryUpdated(address newFactory);
-
-    constructor(address _factory) {
-        require(address(_factory) != address(0), "NRS: INVALID_FACTORY_ADDRESS");
-        factory = _factory;
-    }
-
-    /// @dev Reverts if the caller is not the factory
-    modifier onlyFactory() {
-        require(_msgSender() == factory, "NRS: UNAUTHORIZED");
-        _;
-    }
 
     /// @notice Release funds to a recipient
     /// @param _recipient The receiver
@@ -44,14 +27,6 @@ contract NestedReserve is Ownable {
     /// @param _token The ERC20 to transfer
     /// @param _amount The amount to transfer
     function withdraw(IERC20 _token, uint256 _amount) external onlyFactory {
-        _token.safeTransfer(factory, _amount);
-    }
-
-    /// @notice Update the factory address
-    /// @param _newFactory The new factory address
-    function updateFactory(address _newFactory) external onlyOwner {
-        require(_newFactory != address(0), "NRS: INVALID_ADDRESS");
-        factory = _newFactory;
-        emit FactoryUpdated(_newFactory);
+        _token.safeTransfer(msg.sender, _amount);
     }
 }

--- a/contracts/abstracts/OwnableFactoryHandler.sol
+++ b/contracts/abstracts/OwnableFactoryHandler.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+abstract contract OwnableFactoryHandler is Ownable {
+    /// @dev Emitted when a new factory is added
+    /// @param newFactory Address of the new factory
+    event FactoryAdded(address newFactory);
+
+    /// @dev Emitted when a factory is removed
+    /// @param oldFactory Address of the removed factory
+    event FactoryRemoved(address oldFactory);
+
+    /// @dev Supported factories to interact with
+    mapping(address => bool) public supportedFactories;
+
+    /// @dev Reverts the transaction if the caller is a supported factory
+    modifier onlyFactory() {
+        require(supportedFactories[msg.sender], "OFH: FORBIDDEN");
+        _;
+    }
+
+    /// @notice Add a supported factory
+    /// @param _factory The address of the new factory
+    function addFactory(address _factory) external onlyOwner {
+        require(_factory != address(0), "OFH: INVALID_ADDRESS");
+        supportedFactories[_factory] = true;
+        emit FactoryAdded(_factory);
+    }
+
+    /// @notice Remove a supported factory
+    /// @param _factory The address of the factory to remove
+    function removeFactory(address _factory) external onlyOwner {
+        require(supportedFactories[_factory], "OFH: NOT_SUPPORTED");
+        supportedFactories[_factory] = false;
+        emit FactoryRemoved(_factory);
+    }
+}

--- a/contracts/interfaces/INestedFactory.sol
+++ b/contracts/interfaces/INestedFactory.sol
@@ -48,10 +48,6 @@ interface INestedFactory {
     /// @param operator The operator name to remove
     function removeOperator(bytes32 operator) external;
 
-    /// @notice Sets the reserve where the funds are stored
-    /// @param _reserve the address of the new reserve
-    function setReserve(NestedReserve _reserve) external;
-
     /// @notice Sets the address receiving the fees
     /// @param _feeSplitter The address of the receiver
     function setFeeSplitter(FeeSplitter _feeSplitter) external;

--- a/scripts/deployAll.ts
+++ b/scripts/deployAll.ts
@@ -55,6 +55,11 @@ async function main(): Promise<void> {
     await verify("NestedRecords", nestedRecords, [maxHoldingsCount]);
     console.log("NestedRecords deployed : ", nestedRecords.address);
 
+    // Deploy NestedReserve
+    const nestedReserve = await nestedReserveFactory.deploy();
+    await verify("NestedReserve", nestedReserve, []);
+    console.log("NestedReserve deployed : ", nestedReserve.address);
+
     // Deploy OperatorResolver
     const operatorResolver = await operatorResolverFactory.deploy();
     await verify("OperatorResolver", operatorResolver, []);
@@ -75,30 +80,25 @@ async function main(): Promise<void> {
         .deploy(
             nestedAsset.address,
             nestedRecords.address,
+            nestedReserve.address,
             feeSplitter.address,
             WETH,
             operatorResolver.address,
         );
     await verify("NestedFactory", nestedFactory, [nestedAsset.address,
         nestedRecords.address,
+        nestedReserve.address,
         feeSplitter.address,
         WETH,
         operatorResolver.address]);
     console.log("NestedFactory deployed : ", nestedFactory.address);
 
-    // Deploy NestedReserve
-    const nestedReserve = await nestedReserveFactory.deploy(nestedFactory.address);
-    await verify("NestedReserve", nestedReserve, [nestedFactory.address]);
-    console.log("NestedReserve deployed : ", nestedReserve.address);
-
-    // Set factory to asset and records
-    let tx = await nestedAsset.setFactory(nestedFactory.address);
+    // Set factory to asset, records and reserve
+    let tx = await nestedAsset.addFactory(nestedFactory.address);
     await tx.wait();
-    tx = await nestedRecords.setFactory(nestedFactory.address);
+    tx = await nestedRecords.addFactory(nestedFactory.address);
     await tx.wait();
-
-    // Set reserve to factory
-    tx = await nestedFactory.setReserve(nestedReserve.address);
+    tx = await nestedReserve.addFactory(nestedFactory.address);
     await tx.wait();
 
     // Add operators to OperatorResolver

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -143,6 +143,11 @@ export const factoryAndOperatorsFixture: Fixture<FactoryAndOperatorsFixture> = a
     const nestedRecords = await nestedRecordsFactory.connect(masterDeployer).deploy(maxHoldingsCount);
     await nestedRecords.deployed();
 
+    // Deploy Reserve
+    const nestedReserveFactory = await ethers.getContractFactory("NestedReserve");
+    const nestedReserve = await nestedReserveFactory.connect(masterDeployer).deploy();
+    await nestedReserve.deployed();
+
     // Deploy OperatorResolver
     const operatorResolverFactory = await ethers.getContractFactory("OperatorResolver");
     const operatorResolver = await operatorResolverFactory.connect(masterDeployer).deploy();
@@ -170,23 +175,20 @@ export const factoryAndOperatorsFixture: Fixture<FactoryAndOperatorsFixture> = a
         .deploy(
             nestedAsset.address,
             nestedRecords.address,
+            nestedReserve.address,
             feeSplitter.address,
             WETH.address,
             operatorResolver.address,
         );
     await nestedFactory.deployed();
 
-    // Deploy Reserve
-    const nestedReserveFactory = await ethers.getContractFactory("NestedReserve");
-    const nestedReserve = await nestedReserveFactory.connect(masterDeployer).deploy(nestedFactory.address);
-    await nestedReserve.deployed();
-
     // Get the user1 actor
     const user1 = new ActorFixture(wallets as Wallet[], provider).user1();
 
-    // Set factory to asset and records
-    await nestedAsset.connect(masterDeployer).setFactory(nestedFactory.address);
-    await nestedRecords.connect(masterDeployer).setFactory(nestedFactory.address);
+    // Set factory to asset, records and reserve
+    await nestedAsset.connect(masterDeployer).addFactory(nestedFactory.address);
+    await nestedRecords.connect(masterDeployer).addFactory(nestedFactory.address);
+    await nestedReserve.connect(masterDeployer).addFactory(nestedFactory.address);
 
     // Add operators to OperatorResolver
     const zeroExOperatorNameBytes32 = toBytes32("ZeroEx");

--- a/test/unit/FlatOperator.unit.ts
+++ b/test/unit/FlatOperator.unit.ts
@@ -23,7 +23,6 @@ describe("FlatOperator", () => {
 
     beforeEach("create fixture loader", async () => {
         context = await loadFixture(factoryAndOperatorsFixture);
-        await context.nestedFactory.connect(context.masterDeployer).setReserve(context.nestedReserve.address);
     });
 
     it("deploys and has an address", async () => {

--- a/test/unit/NestedFactory.unit.ts
+++ b/test/unit/NestedFactory.unit.ts
@@ -147,33 +147,6 @@ describe("NestedFactory", () => {
         });
     });
 
-    describe("setReserve()", () => {
-        const newReserve = Wallet.createRandom().address;
-        it("cant be invoked by an user", async () => {
-            await expect(context.nestedFactory.connect(context.user1).setReserve(newReserve)).to.be.revertedWith(
-                "Ownable: caller is not the owner",
-            );
-        });
-
-        it("cant set address (immutable)", async () => {
-            await context.nestedFactory.connect(context.masterDeployer).setReserve(context.nestedReserve.address);
-            await expect(
-                context.nestedFactory.connect(context.masterDeployer).setReserve(newReserve),
-            ).to.be.revertedWith("NF: RESERVE_ADDRESS_IMMUTABLE");
-        });
-
-        it("set value", async () => {
-            await context.nestedFactory.connect(context.masterDeployer).setReserve(context.nestedReserve.address);
-            expect(await context.nestedFactory.reserve()).to.be.equal(context.nestedReserve.address);
-        });
-
-        it("emit ReserveUpdated event", async () => {
-            await expect(context.nestedFactory.connect(context.masterDeployer).setReserve(newReserve))
-                .to.emit(context.nestedFactory, "ReserveUpdated")
-                .withArgs(newReserve);
-        });
-    });
-
     describe("setFeeSplitter()", () => {
         const newFeeSplitter = Wallet.createRandom().address;
         it("cant be invoked by an user", async () => {
@@ -201,10 +174,6 @@ describe("NestedFactory", () => {
     });
 
     describe("create()", () => {
-        beforeEach("Set reserve", async () => {
-            await context.nestedFactory.connect(context.masterDeployer).setReserve(context.nestedReserve.address);
-        });
-
         it("reverts if Orders list is empty", async () => {
             let orders: OrderStruct[] = [];
             await expect(
@@ -528,10 +497,7 @@ describe("NestedFactory", () => {
         let baseExpectedFee = getExpectedFees(baseTotalToBought);
         let baseTotalToSpend = baseTotalToBought.add(baseExpectedFee);
 
-        beforeEach("Set reserve and create NFT (id 1)", async () => {
-            // set reserve
-            await context.nestedFactory.connect(context.masterDeployer).setReserve(context.nestedReserve.address);
-
+        beforeEach("Create NFT (id 1)", async () => {
             // create nft 1 with UNI and KNC from DAI (use the base amounts)
             let orders: OrderStruct[] = getUniAndKncWithDaiOrders(baseUniBought, baseKncBought);
             await context.nestedFactory
@@ -845,10 +811,7 @@ describe("NestedFactory", () => {
         let baseExpectedFee = getExpectedFees(baseTotalToBought);
         let baseTotalToSpend = baseTotalToBought.add(baseExpectedFee);
 
-        beforeEach("Set reserve and create NFT (id 1)", async () => {
-            // set reserve
-            await context.nestedFactory.connect(context.masterDeployer).setReserve(context.nestedReserve.address);
-
+        beforeEach("Create NFT (id 1)", async () => {
             // create nft 1 with UNI and KNC from DAI (use the base amounts)
             let orders: OrderStruct[] = getUniAndKncWithDaiOrders(baseUniBought, baseKncBought);
             await context.nestedFactory
@@ -1120,10 +1083,7 @@ describe("NestedFactory", () => {
         let baseExpectedFee = getExpectedFees(baseTotalToBought);
         let baseTotalToSpend = baseTotalToBought.add(baseExpectedFee);
 
-        beforeEach("Set reserve and create NFT (id 1)", async () => {
-            // set reserve
-            await context.nestedFactory.connect(context.masterDeployer).setReserve(context.nestedReserve.address);
-
+        beforeEach("Create NFT (id 1)", async () => {
             // create nft 1 with UNI and KNC from DAI (use the base amounts)
             let orders: OrderStruct[] = getUniAndKncWithDaiOrders(baseUniBought, baseKncBought);
             await context.nestedFactory
@@ -1399,10 +1359,7 @@ describe("NestedFactory", () => {
         let baseExpectedFee = getExpectedFees(baseTotalToBought);
         let baseTotalToSpend = baseTotalToBought.add(baseExpectedFee);
 
-        beforeEach("Set reserve and create NFT (id 1)", async () => {
-            // set reserve
-            await context.nestedFactory.connect(context.masterDeployer).setReserve(context.nestedReserve.address);
-
+        beforeEach("Create NFT (id 1)", async () => {
             // create nft 1 with UNI and KNC from DAI (use the base amounts)
             let orders: OrderStruct[] = getUniAndKncWithDaiOrders(baseUniBought, baseKncBought);
             await context.nestedFactory
@@ -1667,10 +1624,7 @@ describe("NestedFactory", () => {
         let baseExpectedFee = getExpectedFees(baseTotalToBought);
         let baseTotalToSpend = baseTotalToBought.add(baseExpectedFee);
 
-        beforeEach("Set reserve and create NFT (id 1)", async () => {
-            // set reserve
-            await context.nestedFactory.connect(context.masterDeployer).setReserve(context.nestedReserve.address);
-
+        beforeEach("Create NFT (id 1)", async () => {
             // create nft 1 with UNI and KNC from DAI (use the base amounts)
             let orders: OrderStruct[] = getUniAndKncWithDaiOrders(baseUniBought, baseKncBought);
             await context.nestedFactory
@@ -1901,10 +1855,7 @@ describe("NestedFactory", () => {
         let baseExpectedFee = getExpectedFees(baseTotalToBought);
         let baseTotalToSpend = baseTotalToBought.add(baseExpectedFee);
 
-        beforeEach("Set reserve and create NFT (id 1)", async () => {
-            // set reserve
-            await context.nestedFactory.connect(context.masterDeployer).setReserve(context.nestedReserve.address);
-
+        beforeEach("Create NFT (id 1)", async () => {
             // create nft 1 with UNI and KNC from DAI (use the base amounts)
             let orders: OrderStruct[] = getUniAndKncWithDaiOrders(baseUniBought, baseKncBought);
             await context.nestedFactory
@@ -1969,10 +1920,7 @@ describe("NestedFactory", () => {
         let baseExpectedFee = getExpectedFees(baseTotalToBought);
         let baseTotalToSpend = baseTotalToBought.add(baseExpectedFee);
 
-        beforeEach("Set reserve and create NFT (id 1)", async () => {
-            // set reserve
-            await context.nestedFactory.connect(context.masterDeployer).setReserve(context.nestedReserve.address);
-
+        beforeEach("Create NFT (id 1)", async () => {
             // create nft 1 with UNI and KNC from DAI (use the base amounts)
             let orders: OrderStruct[] = getUniAndKncWithDaiOrders(baseUniBought, baseKncBought);
             await context.nestedFactory

--- a/test/unit/NestedRecords.unit.ts
+++ b/test/unit/NestedRecords.unit.ts
@@ -17,15 +17,15 @@ describe("NestedRecords", () => {
     beforeEach(async () => {
         NestedRecords = await ethers.getContractFactory("NestedRecords");
         nestedRecords = await NestedRecords.deploy(15);
-        nestedRecords.setFactory(alice.address);
+        nestedRecords.addFactory(alice.address);
     });
 
     it("reverts when setting invalid factory", async () => {
-        await expect(nestedRecords.setFactory(ethers.constants.AddressZero)).to.be.revertedWith("NRC: INVALID_ADDRESS");
+        await expect(nestedRecords.addFactory(ethers.constants.AddressZero)).to.be.revertedWith("OFH: INVALID_ADDRESS");
     });
 
     it("reverts when calling a factory only function when not a factory", async () => {
-        await expect(nestedRecords.connect(bob).setReserve(0, bob.address)).to.be.revertedWith("NRC: FORBIDDEN");
+        await expect(nestedRecords.connect(bob).setReserve(0, bob.address)).to.be.revertedWith("OFH: FORBIDDEN");
     });
 
     it("reverts when setting a wrong reserve to a NFT", async () => {

--- a/test/unit/NestedReserve.unit.ts
+++ b/test/unit/NestedReserve.unit.ts
@@ -21,35 +21,12 @@ describe("NestedReserve", () => {
     });
 
     beforeEach(async () => {
-        reserve = await nestedReserve.deploy(factory.address);
+        reserve = await nestedReserve.deploy();
         await reserve.deployed();
+        await reserve.addFactory(factory.address);
 
         mockUNI = await mockERC20.deploy("Mocked UNI", "INU", 0);
         await mockUNI.mint(reserve.address, amountToTransfer);
-    });
-
-    describe("#initialization", () => {
-        it("sets the state variable", async () => {
-            expect(await reserve.factory()).to.eq(factory.address);
-        });
-
-        it("sets a new factory", async () => {
-            const tx = await reserve.updateFactory(bob.address);
-            await tx.wait();
-            expect(await reserve.factory()).to.eq(bob.address);
-        });
-
-        it("should revert if unauthorized account sets the factory", async () => {
-            await expect(reserve.connect(bob).updateFactory(bob.address)).to.be.revertedWith(
-                "Ownable: caller is not the owner",
-            );
-        });
-
-        it("should revert if sets the factory with address zero", async () => {
-            await expect(reserve.updateFactory(ethers.constants.AddressZero)).to.be.revertedWith(
-                "NRS: INVALID_ADDRESS",
-            );
-        });
     });
 
     describe("#transfer", async () => {
@@ -67,7 +44,7 @@ describe("NestedReserve", () => {
         it("reverts if the recipient if unauthorized", async () => {
             await expect(
                 reserve.connect(alice).transfer(alice.address, mockUNI.address, amountToTransfer),
-            ).to.be.revertedWith("NRS: UNAUTHORIZED");
+            ).to.be.revertedWith("OFH: FORBIDDEN");
         });
 
         it("reverts if the token is invalid", async () => {
@@ -97,7 +74,7 @@ describe("NestedReserve", () => {
 
         it("reverts if the recipient if unauthorized", async () => {
             await expect(reserve.connect(alice).withdraw(mockUNI.address, amountToTransfer)).to.be.revertedWith(
-                "NRS: UNAUTHORIZED",
+                "OFH: FORBIDDEN",
             );
         });
 

--- a/test/unit/OwnableFactoryHandler.unit.ts
+++ b/test/unit/OwnableFactoryHandler.unit.ts
@@ -1,0 +1,72 @@
+import { LoadFixtureFunction } from "../types";
+import { factoryAndOperatorsFixture, FactoryAndOperatorsFixture } from "../shared/fixtures";
+import { createFixtureLoader, expect, provider } from "../shared/provider";
+import { ethers, network } from "hardhat";
+import { Wallet } from "ethers";
+
+let loadFixture: LoadFixtureFunction;
+
+describe("OwnableFactoryHandler", () => {
+    let context: FactoryAndOperatorsFixture;
+    const otherFactory = Wallet.createRandom();
+
+    before("loader", async () => {
+        loadFixture = createFixtureLoader(provider.getWallets(), provider);
+    });
+
+    beforeEach("create fixture loader", async () => {
+        context = await loadFixture(factoryAndOperatorsFixture);
+    });
+
+    describe("addFactory()", () => {
+        it("sets the new factory", async () => {
+            await expect(context.nestedAsset.connect(context.masterDeployer).addFactory(otherFactory.address))
+                .to.emit(context.nestedAsset, "FactoryAdded")
+                .withArgs(otherFactory.address);
+            expect(await context.nestedAsset.supportedFactories(otherFactory.address)).to.equal(true);
+        });
+
+        it("reverts if unauthorized", async () => {
+            await expect(
+                context.nestedAsset.connect(context.user1).addFactory(otherFactory.address),
+            ).to.be.revertedWith("Ownable: caller is not the owner");
+            expect(await context.nestedAsset.supportedFactories(otherFactory.address)).to.equal(false);
+        });
+
+        it("reverts if the address is invalid", async () => {
+            await expect(
+                context.nestedAsset.connect(context.masterDeployer).addFactory(ethers.constants.AddressZero),
+            ).to.be.revertedWith("OFH: INVALID_ADDRESS");
+            expect(await context.nestedAsset.supportedFactories(otherFactory.address)).to.equal(false);
+        });
+    });
+
+    describe("removeFactory()", () => {
+        it("remove a factory", async () => {
+            await context.nestedAsset.connect(context.masterDeployer).addFactory(otherFactory.address);
+            expect(await context.nestedAsset.supportedFactories(otherFactory.address)).to.equal(true);
+            await expect(context.nestedAsset.connect(context.masterDeployer).removeFactory(otherFactory.address))
+                .to.emit(context.nestedAsset, "FactoryRemoved")
+                .withArgs(otherFactory.address);
+            expect(await context.nestedAsset.supportedFactories(otherFactory.address)).to.equal(false);
+        });
+
+        it("reverts if unauthorized", async () => {
+            await context.nestedAsset.connect(context.masterDeployer).addFactory(otherFactory.address);
+            await expect(
+                context.nestedAsset.connect(context.user1).removeFactory(otherFactory.address),
+            ).to.be.revertedWith("Ownable: caller is not the owner");
+            expect(await context.nestedAsset.supportedFactories(otherFactory.address)).to.equal(true);
+        });
+
+        it("reverts if already not supported", async () => {
+            await expect(
+                context.nestedAsset.connect(context.masterDeployer).removeFactory(otherFactory.address),
+            ).to.be.revertedWith("OFH: NOT_SUPPORTED");
+
+            await expect(
+                context.nestedAsset.connect(context.masterDeployer).removeFactory(ethers.constants.AddressZero),
+            ).to.be.revertedWith("OFH: NOT_SUPPORTED");
+        });
+    });
+});


### PR DESCRIPTION
Issues =>
- https://github.com/code-423n4/2021-11-nested-findings/issues/32
- https://github.com/code-423n4/2021-11-nested-findings/issues/204
- https://github.com/code-423n4/2021-11-nested-findings/issues/203

The idea here is to introduce an abstract contract `OwnableFactoryHandler` to remove duplicated code towards `supportedFactories` (and associated functions/modifier). And `NestedReserve` is now an `OwnableFactoryHandler`.