### PR TITLE
Move to Solmate ERC721

### DIFF
--- a/contracts/NestedAsset.sol
+++ b/contracts/NestedAsset.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.9;
 
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@rari-capital/solmate/src/tokens/ERC721.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "./abstracts/OwnableFactoryHandler.sol";
 
 /// @title Collection of NestedNFTs used to represent ownership of real assets stored in NestedReserves
 /// @dev Only NestedFactory contracts are allowed to call functions that write to storage
-contract NestedAsset is ERC721Enumerable, OwnableFactoryHandler {
+contract NestedAsset is ERC721, OwnableFactoryHandler {
     using Counters for Counters.Counter;
 
     Counters.Counter private _tokenIds;
@@ -25,7 +25,7 @@ contract NestedAsset is ERC721Enumerable, OwnableFactoryHandler {
 
     /// @dev Reverts the transaction if the address is not the token owner
     modifier onlyTokenOwner(address _address, uint256 _tokenId) {
-        require(_address == ownerOf(_tokenId), "NA: FORBIDDEN_NOT_OWNER");
+        require(_address == ownerOf[_tokenId], "NA: FORBIDDEN_NOT_OWNER");
         _;
     }
 
@@ -45,7 +45,7 @@ contract NestedAsset is ERC721Enumerable, OwnableFactoryHandler {
         uint256 originalAssetId = originalAsset[_tokenId];
 
         if (originalAssetId != 0) {
-            return _exists(originalAssetId) ? ownerOf(originalAssetId) : lastOwnerBeforeBurn[originalAssetId];
+            return _exists(originalAssetId) ? ownerOf[originalAssetId] : lastOwnerBeforeBurn[originalAssetId];
         }
         return address(0);
     }
@@ -119,5 +119,9 @@ contract NestedAsset is ERC721Enumerable, OwnableFactoryHandler {
     /// @param _metadataURI The metadata URI string
     function _setTokenURI(uint256 _tokenId, string memory _metadataURI) internal {
         _tokenURIs[_tokenId] = _metadataURI;
+    }
+
+    function _exists(uint256 _tokenId) internal view returns (bool) {
+        return ownerOf[_tokenId] != address(0);
     }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     },
     "dependencies": {
         "@openzeppelin/contracts": "^4.3.2",
+        "@rari-capital/solmate": "^6.2.0",
         "inquirer": "^8.1.0"
     }
 }

--- a/test/unit/FlatOperator.unit.ts
+++ b/test/unit/FlatOperator.unit.ts
@@ -162,6 +162,6 @@ describe("FlatOperator", () => {
         );
 
         // The NFT is burned
-        await expect(context.nestedAsset.ownerOf(1)).to.be.revertedWith("ERC721: owner query for nonexistent token");
+        expect(await context.nestedAsset.ownerOf(1)).to.be.equal(ethers.constants.AddressZero);
     });
 });

--- a/test/unit/NestedAsset.unit.ts
+++ b/test/unit/NestedAsset.unit.ts
@@ -39,9 +39,9 @@ describe("NestedAsset", () => {
                 await asset.mint(bob.address, 0);
                 expect(await asset.balanceOf(alice.address)).to.equal("2");
                 expect(await asset.balanceOf(bob.address)).to.equal("1");
-                expect(await asset.tokenOfOwnerByIndex(alice.address, 0)).to.equal("1");
-                expect(await asset.tokenOfOwnerByIndex(alice.address, 1)).to.equal("2");
-                expect(await asset.tokenOfOwnerByIndex(bob.address, 0)).to.equal("3");
+                expect(await asset.ownerOf(1)).to.equal(alice.address);
+                expect(await asset.ownerOf(2)).to.equal(alice.address);
+                expect(await asset.ownerOf(3)).to.equal(bob.address);
             });
         });
 
@@ -70,8 +70,7 @@ describe("NestedAsset", () => {
     describe("#tokenURI", () => {
         it("should display NFT metadata", async () => {
             await asset.mintWithMetadata(alice.address, metadataUri, 0);
-            const tokenId = await asset.tokenOfOwnerByIndex(alice.address, 0);
-            expect(await asset.tokenURI(tokenId)).to.equal(metadataUri);
+            expect(await asset.tokenURI(1)).to.equal(metadataUri);
         });
 
         it("reverts if the token does not exist", async () => {
@@ -97,7 +96,7 @@ describe("NestedAsset", () => {
         });
 
         it("should revert when burning non existing token", async () => {
-            await expect(asset.burn(alice.address, 1)).to.be.revertedWith("ERC721: owner query for nonexistent token");
+            await expect(asset.burn(alice.address, 1)).to.be.revertedWith("NA: FORBIDDEN_NOT_OWNER");
         });
 
         it("should revert if the caller is not the factory", async () => {

--- a/test/unit/NestedFactory.unit.ts
+++ b/test/unit/NestedFactory.unit.ts
@@ -594,7 +594,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .addTokens(2, context.mockDAI.address, totalToSpend, orders),
-            ).to.be.revertedWith("ERC721: owner query for nonexistent token");
+            ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
         it("cant add tokens to another user portfolio", async () => {
@@ -912,7 +912,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .swapTokenForTokens(2, context.mockDAI.address, totalToSpend, orders),
-            ).to.be.revertedWith("ERC721: owner query for nonexistent token");
+            ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
         it("cant swap token from another user portfolio", async () => {
@@ -1167,7 +1167,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .sellTokensToNft(2, context.mockUSDC.address, [uniSold, kncSold], orders),
-            ).to.be.revertedWith("ERC721: owner query for nonexistent token");
+            ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
         it("cant swap tokens from another user portfolio", async () => {
@@ -1439,7 +1439,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .sellTokensToWallet(2, context.mockUSDC.address, [uniSold, kncSold], orders),
-            ).to.be.revertedWith("ERC721: owner query for nonexistent token");
+            ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
         it("cant swap tokens from another user portfolio", async () => {
@@ -1710,7 +1710,7 @@ describe("NestedFactory", () => {
             // NFT with id = 2 shouldn't exist
             await expect(
                 context.nestedFactory.connect(context.user1).destroy(2, context.mockUSDC.address, orders),
-            ).to.be.revertedWith("ERC721: owner query for nonexistent token");
+            ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
         it("cant swap tokens from another user portfolio", async () => {
@@ -1785,9 +1785,7 @@ describe("NestedFactory", () => {
             );
 
             // The NFT is burned
-            await expect(context.nestedAsset.ownerOf(1)).to.be.revertedWith(
-                "ERC721: owner query for nonexistent token",
-            );
+            expect(await context.nestedAsset.ownerOf(1)).to.be.equal(ethers.constants.AddressZero);
         });
 
         it("delete nft for USDC with right amounts", async () => {
@@ -1812,9 +1810,7 @@ describe("NestedFactory", () => {
             );
 
             // The NFT is burned
-            await expect(context.nestedAsset.ownerOf(1)).to.be.revertedWith(
-                "ERC721: owner query for nonexistent token",
-            );
+            expect(await context.nestedAsset.ownerOf(1)).to.be.equal(ethers.constants.AddressZero);
         });
 
         it("delete nft for ETH with right amounts", async () => {
@@ -1837,9 +1833,7 @@ describe("NestedFactory", () => {
             );
 
             // The NFT is burned
-            await expect(context.nestedAsset.ownerOf(1)).to.be.revertedWith(
-                "ERC721: owner query for nonexistent token",
-            );
+            expect(await context.nestedAsset.ownerOf(1)).to.be.equal(ethers.constants.AddressZero);
         });
 
         it("delete nft for USDC with UNI leftovers", async () => {
@@ -1864,9 +1858,7 @@ describe("NestedFactory", () => {
             );
 
             // The NFT is burned
-            await expect(context.nestedAsset.ownerOf(1)).to.be.revertedWith(
-                "ERC721: owner query for nonexistent token",
-            );
+            expect(await context.nestedAsset.ownerOf(1)).to.be.equal(ethers.constants.AddressZero);
         });
     });
 
@@ -1894,7 +1886,7 @@ describe("NestedFactory", () => {
 
         it("cant withdraw from nonexistent portfolio", async () => {
             await expect(context.nestedFactory.connect(context.user1).withdraw(2, 1)).to.be.revertedWith(
-                "ERC721: owner query for nonexistent token",
+                "NF: CALLER_NOT_OWNER",
             );
         });
 
@@ -1960,7 +1952,7 @@ describe("NestedFactory", () => {
         it("cant increase nonexistent portfolio", async () => {
             await expect(
                 context.nestedFactory.connect(context.user1).increaseLockTimestamp(2, Date.now()),
-            ).to.be.revertedWith("ERC721: owner query for nonexistent token");
+            ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
         it("cant decrease timestamp", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,6 +1088,11 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.2.tgz#ff80affd6d352dbe1bbc5b4e1833c41afd6283b6"
   integrity sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg==
 
+"@rari-capital/solmate@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@rari-capital/solmate/-/solmate-6.2.0.tgz#4f70dc236606c27ec2cb1b4261dd830235d01fe4"
+  integrity sha512-g94F+Ra9ixyJyNgvnOIufNjUz488uEG0nxIEEtJ7+g+tA1XGUupRB2kB5b+VO7WYO26RNOVD2fW6xE4e14iWpg==
+
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@resolver-engine/core/-/core-0.3.3.tgz#590f77d85d45bc7ecc4e06c654f41345db6ca967"


### PR DESCRIPTION
The idea is to move from OpenZeppelin to Solmate (a more "modern, opinionated, and gas optimized" lib) on `NestedAsset`

In this PR, `NestedAsset` is now using => https://github.com/Rari-Capital/solmate/blob/main/src/tokens/ERC721.sol

However, some functions from `ERC721Enumerable` are removed, like `tokenOfOwnerByIndex`. So we have to make sure that It's not impacting the front-end/back-end.

With gas price of 100 Gwei on Ethereum and ETH at 3300$, here are the optimizations :
- Create : 680085 => 607698 **(-25$)**
- Destroy : 348419 => 333332 **(-5$)**

