### PR TITLE
fix: remove useless transfers (`destroy`)

### DIFF
--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -463,7 +463,10 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, OwnableProxyDelegatio
         if (success) {
             require(amounts[1] <= _amountToSpend, "NF: OVERSPENT");
             unchecked {
-                _safeTransferWithFees(IERC20(_inputToken), _amountToSpend - amounts[1], _msgSender(), _nftId);
+                uint256 underSpentAmount = _amountToSpend - amounts[1];
+                if (underSpentAmount != 0) {
+                    SafeERC20.safeTransfer(IERC20(_inputToken), _msgSender(), underSpentAmount);
+                }
             }
         } else {
             _safeTransferWithFees(IERC20(_inputToken), _amountToSpend, _msgSender(), _nftId);


### PR DESCRIPTION
When we are calling the `destroy` function, we are doing some transfers with the amount = 0... 
![image](https://user-images.githubusercontent.com/22816913/162974552-89dc91e9-2139-43af-85a9-b2c9493cb93e.png)

In `_safeSubmitOrder` (only called in `destroy`) : 

```javascript
function _safeSubmitOrder(
    address _inputToken,
    address _outputToken,
    uint256 _amountToSpend,
    uint256 _nftId,
    Order calldata _order
) private {
    (bool success, uint256[] memory amounts) = callOperator(_order, _inputToken, _outputToken);
    if (success) {
        require(amounts[1] <= _amountToSpend, "NF: OVERSPENT");
        unchecked { 
            // ERROR : Transfer even if _amountToSpend - amounts[1] == 0
            _safeTransferWithFees(IERC20(_inputToken), _amountToSpend - amounts[1], _msgSender(), _nftId);
        }
    } else {
        _safeTransferWithFees(IERC20(_inputToken), _amountToSpend, _msgSender(), _nftId);
    }
}
```

We are transferring the underspent amount even if it's equal to zero. Also, we are transferring with fees, but we should not collect fees on the underspent amount.

## Fix 
```javascript
function _safeSubmitOrder(
    address _inputToken,
    address _outputToken,
    uint256 _amountToSpend,
    uint256 _nftId,
    Order calldata _order
) private {
    (bool success, uint256[] memory amounts) = callOperator(_order, _inputToken, _outputToken)
    if (success) {
        require(amounts[1] <= _amountToSpend, "NF: OVERSPENT");
        unchecked {
            uint256 underSpentAmount = _amountToSpend - amounts[1];
            if (underSpentAmount != 0) { // FIX : Check if amount is equal to zero
                // FIX : Transfer without fees
                SafeERC20.safeTransfer(IERC20(_inputToken), _msgSender(), underSpentAmount);
            }
        }
    } else {
        _safeTransferWithFees(IERC20(_inputToken), _amountToSpend, _msgSender(), _nftId);
    }
}
```
