### PR TITLE
feat: Upgradeable Fees

### DIFF
--- a/contracts/abstracts/OwnableProxyDelegation.sol
+++ b/contracts/abstracts/OwnableProxyDelegation.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/utils/StorageSlot.sol";
 
 /// @notice Ownable re-implementation to initialize the owner in the
-///         proxy storage after an "upgradeToAndCall()` (delegatecall).
+///         proxy storage after an "upgradeToAndCall()" (delegatecall).
 /// @dev The implementation contract owner will be address zero (by removing the constructor)
 abstract contract OwnableProxyDelegation is Context {
     /// @dev The contract owner

--- a/contracts/interfaces/INestedFactory.sol
+++ b/contracts/interfaces/INestedFactory.sol
@@ -13,6 +13,14 @@ interface INestedFactory {
     /// @param feeSplitter The new feeSplitter address
     event FeeSplitterUpdated(address feeSplitter);
 
+    /// @dev Emitted when the entryFees is updated
+    /// @param entryFees The new entryFees amount
+    event EntryFeesUpdated(uint256 entryFees);
+
+    /// @dev Emitted when the exitFees is updated
+    /// @param exitFees The new exitFees amount
+    event ExitFeesUpdated(uint256 exitFees);
+
     /// @dev Emitted when the reserve is updated
     /// @param reserve The new reserve address
     event ReserveUpdated(address reserve);
@@ -90,6 +98,16 @@ interface INestedFactory {
     /// @notice Sets the address receiving the fees
     /// @param _feeSplitter The address of the receiver
     function setFeeSplitter(FeeSplitter _feeSplitter) external;
+
+    /// @notice Sets the entry fees amount
+    ///         Where 1 = 0.01% and 10000 = 100%
+    /// @param _entryFees Entry fees amount
+    function setEntryFees(uint256 _entryFees) external;
+
+    /// @notice Sets the exit fees amount
+    ///         Where 1 = 0.01% and 10000 = 100%
+    /// @param _exitFees Exit fees amount
+    function setExitFees(uint256 _exitFees) external;
 
     /// @notice The Factory is not storing funds, but some users can make
     /// bad manipulations and send tokens to the contract.

--- a/scripts/deployAll.ts
+++ b/scripts/deployAll.ts
@@ -133,6 +133,12 @@ async function main(): Promise<void> {
     // Reset feeSplitter in proxy storage
     await run(await proxyImpl.setFeeSplitter(feeSplitter.address));
 
+    // Set entry fees in proxy storage
+    await run(await proxyImpl.setEntryFees(30));
+
+    // Set exit fees in proxy storage
+    await run(await proxyImpl.setExitFees(80));
+
     await importOperators(operatorResolver, [registerFlat(flatOperator), registerZeroEx(zeroExOperator)], proxyImpl);
 
     // Convert JSON object to string

--- a/scripts/deployFullFactory.ts
+++ b/scripts/deployFullFactory.ts
@@ -117,6 +117,14 @@ async function main(): Promise<void> {
     tx = await proxyImpl.setFeeSplitter(feeSplitter.address);
     await tx.wait();
 
+    // Set entry fees in proxy storage
+    tx = await proxyImpl.setEntryFees(30);
+    await tx.wait();
+
+    // Set exit fees in proxy storage
+    tx = await proxyImpl.setExitFees(80);
+    await tx.wait();
+
     await importOperators(operatorResolver, [registerFlat(flatOperator), registerZeroEx(zeroExOperator)], proxyImpl);
 
     // Convert JSON object to string

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -310,6 +310,14 @@ export const factoryAndOperatorsFixture: Fixture<FactoryAndOperatorsFixture> = a
     tx = await nestedFactory.connect(masterDeployer).setFeeSplitter(feeSplitter.address);
     await tx.wait();
 
+    // Set entry fees in proxy storage
+    tx = await nestedFactory.connect(masterDeployer).setEntryFees(100);
+    await tx.wait();
+
+    // Set exit fees in proxy storage
+    tx = await nestedFactory.connect(masterDeployer).setExitFees(100);
+    await tx.wait();
+
     await importOperatorsWithSigner(
         operatorResolver,
         [registerZeroEx(zeroExOperator), registerFlat(flatOperator), registerParaswap(paraswapOperator)],
@@ -555,6 +563,14 @@ export const factoryAndOperatorsForkingBSCFixture: Fixture<FactoryAndOperatorsFo
 
     // Reset feeSplitter in proxy storage
     tx = await nestedFactory.connect(masterDeployer).setFeeSplitter(feeSplitter.address);
+    await tx.wait();
+
+    // Set entry fees in proxy storage
+    tx = await nestedFactory.connect(masterDeployer).setEntryFees(100);
+    await tx.wait();
+
+    // Set exit fees in proxy storage
+    tx = await nestedFactory.connect(masterDeployer).setExitFees(100);
     await tx.wait();
 
     await importOperatorsWithSigner(

--- a/test/unit/NestedFactory.unit.ts
+++ b/test/unit/NestedFactory.unit.ts
@@ -234,6 +234,68 @@ describeWithoutFork("NestedFactory", () => {
         });
     });
 
+    describe("setEntryFees()", () => {
+        it("cant be invoked by an user", async () => {
+            await expect(
+                context.nestedFactory.connect(context.user1).setEntryFees(100),
+            ).to.be.revertedWith("OPD: NOT_OWNER");
+        });
+
+        it("cant set zero", async () => {
+            await expect(
+                context.nestedFactory.connect(context.masterDeployer).setEntryFees(0),
+            ).to.be.revertedWith("NF: ZERO_FEES");
+        });
+
+        it("cant set more than 10,000", async () => {
+            await expect(
+                context.nestedFactory.connect(context.masterDeployer).setEntryFees(10001),
+            ).to.be.revertedWith("NF: FEES_OVERFLOW");
+        });
+
+        it("set value", async () => {
+            await context.nestedFactory.connect(context.masterDeployer).setEntryFees(10000);
+            expect(await context.nestedFactory.entryFees()).to.be.equal(10000);
+        });
+
+        it("emit EntryFeesUpdated event", async () => {
+            await expect(context.nestedFactory.connect(context.masterDeployer).setEntryFees(100))
+                .to.emit(context.nestedFactory, "EntryFeesUpdated")
+                .withArgs(100);
+        });
+    });
+
+    describe("setExitFees()", () => {
+        it("cant be invoked by an user", async () => {
+            await expect(
+                context.nestedFactory.connect(context.user1).setExitFees(100),
+            ).to.be.revertedWith("OPD: NOT_OWNER");
+        });
+
+        it("cant set zero", async () => {
+            await expect(
+                context.nestedFactory.connect(context.masterDeployer).setExitFees(0),
+            ).to.be.revertedWith("NF: ZERO_FEES");
+        });
+
+        it("cant set more than 10,000", async () => {
+            await expect(
+                context.nestedFactory.connect(context.masterDeployer).setExitFees(10001),
+            ).to.be.revertedWith("NF: FEES_OVERFLOW");
+        });
+
+        it("set value", async () => {
+            await context.nestedFactory.connect(context.masterDeployer).setExitFees(10000);
+            expect(await context.nestedFactory.exitFees()).to.be.equal(10000);
+        });
+
+        it("emit ExitFeesUpdated event", async () => {
+            await expect(context.nestedFactory.connect(context.masterDeployer).setExitFees(100))
+                .to.emit(context.nestedFactory, "ExitFeesUpdated")
+                .withArgs(100);
+        });
+    });
+
     describe("create()", () => {
         it("reverts if Orders list is empty", async () => {
             let orders: utils.OrderStruct[] = [];

--- a/test/unit/NestedFactory.unit.ts
+++ b/test/unit/NestedFactory.unit.ts
@@ -36,7 +36,7 @@ describeWithoutFork("NestedFactory", () => {
     });
 
     describe("addOperator()", () => {
-        it("cant be invoked by an user", async () => {
+        it("cant be invoked by a user", async () => {
             await expect(
                 context.nestedFactory.connect(context.user1).addOperator(toBytes32("test")),
             ).to.be.revertedWith("OPD: NOT_OWNER");
@@ -76,7 +76,7 @@ describeWithoutFork("NestedFactory", () => {
     });
 
     describe("removeOperator()", () => {
-        it("cant be invoked by an user", async () => {
+        it("cant be invoked by a user", async () => {
             await expect(
                 context.nestedFactory.connect(context.user1).removeOperator(toBytes32("test")),
             ).to.be.revertedWith("OPD: NOT_OWNER");
@@ -210,7 +210,7 @@ describeWithoutFork("NestedFactory", () => {
 
     describe("setFeeSplitter()", () => {
         const newFeeSplitter = Wallet.createRandom().address;
-        it("cant be invoked by an user", async () => {
+        it("cant be invoked by a user", async () => {
             await expect(
                 context.nestedFactory.connect(context.user1).setFeeSplitter(newFeeSplitter),
             ).to.be.revertedWith("OPD: NOT_OWNER");
@@ -235,7 +235,7 @@ describeWithoutFork("NestedFactory", () => {
     });
 
     describe("setEntryFees()", () => {
-        it("cant be invoked by an user", async () => {
+        it("cant be invoked by a user", async () => {
             await expect(
                 context.nestedFactory.connect(context.user1).setEntryFees(100),
             ).to.be.revertedWith("OPD: NOT_OWNER");
@@ -266,7 +266,7 @@ describeWithoutFork("NestedFactory", () => {
     });
 
     describe("setExitFees()", () => {
-        it("cant be invoked by an user", async () => {
+        it("cant be invoked by a user", async () => {
             await expect(
                 context.nestedFactory.connect(context.user1).setExitFees(100),
             ).to.be.revertedWith("OPD: NOT_OWNER");

--- a/test/unit/OperatorResolver.unit.ts
+++ b/test/unit/OperatorResolver.unit.ts
@@ -53,7 +53,7 @@ describeWithoutFork("OperatorResolver", () => {
             ).to.not.be.reverted;
         });
 
-        it("cant be invoked by an user", async () => {
+        it("cant be invoked by a user", async () => {
             await expect(
                 context.operatorResolver
                     .connect(actors.user1())


### PR DESCRIPTION
We are introducing the upgradeability of fees and the notion of "EntryFees/ExitFees" (new values) :
- `EntryFees` : Applied when funds stay inside of the portfolio.
- `ExitFees` : Applied when funds are withdrawed from the portfolio.

For each paths we have: 
- `processInputOrders` and `fromReserve` => **EntryFees**
- `processInputOrders` and `!fromReserve` = >**EntryFees**
- `processOutputOrders` and `toReserve` => **EntryFees**
- `processOutputOrders` and `!toReserve` => **ExitFees**
- `withdraw` => **ExitFees**
- `destroy` => **ExitFees**

We will set 0.8% ExitFees and 0.3 EntryFees when deploying. In the tests, fees are 1% and 1%.

Since we are using an TransparentUpgradeableProxy for `NestedFactory`, these two values are at the end of the stack (storage).