### PR TITLE
[New Operator] - Yearn Curve vaults

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -99,13 +99,15 @@ When deploying an operator, it will also deploy the storage contract and transfe
 
 ### Contracts
 
-| Name                  | Purpose  |
-|-----------------------|----------|
-| OperatorResolver      | Allows the factory to identify which operator to interact with. |
-| MixinOperatorResolver | Abstract contract to load authorized operators in cache (instead of calling `OperatorResolver`). |
-| ZeroExOperator        | Performs token swaps through 0x ([read more](contracts/operators/ZeroEx/README.md)). |
-| ZeroExStorage         | ZeroExOperator storage contract. Must store the 0x `swapTarget`. |
-| FlatOperator          | Handles deposits and withdraws. No interaction with any third parties ([read more](contracts/operators/Flat/README.md)). |
+| Name                    | Purpose                                                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| OperatorResolver        | Allows the factory to identify which operator to interact with.                                                          |
+| MixinOperatorResolver   | Abstract contract to load authorized operators in cache (instead of calling `OperatorResolver`).                         |
+| ZeroExOperator          | Performs token swaps through 0x ([read more](contracts/operators/ZeroEx/README.md)).                                     |
+| ZeroExStorage           | ZeroExOperator storage contract. Must store the 0x `swapTarget`.                                                         |
+| FlatOperator            | Handles deposits and withdraws. No interaction with any third parties ([read more](contracts/operators/Flat/README.md)). |
+| YearnCurveVaultOperator | Handles deposits and withdraws in a Yearn LP vault.                                                                      |
+| YearnVaultStorage       | Handles whitelisting of Yearn Vaults.                                                                                    |
 
 _More operators will be added. e.g. CurveOperator or SynthetixOperator_
 

--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -15,8 +15,6 @@ import "./NestedAsset.sol";
 import "./NestedRecords.sol";
 import "./Withdrawer.sol";
 
-import "hardhat/console.sol";
-
 /// @title Creates, updates and destroys NestedAssets (portfolios).
 /// @notice Responsible for the business logic of the protocol and interaction with operators
 contract NestedFactory is INestedFactory, ReentrancyGuard, OwnableProxyDelegation, MixinOperatorResolver {
@@ -85,7 +83,9 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, OwnableProxyDelegatio
 
     /// @dev Receive function
     receive() external payable {
-        require(msg.sender == address(withdrawer), "NF: ETH_SENDER_NOT_WITHDRAWER");
+        if (msg.sender != address(withdrawer)) {
+            weth.deposit{ value: msg.value }();
+        }
     }
 
     /* ------------------------------ MODIFIERS ---------------------------- */

--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -81,7 +81,10 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, OwnableProxyDelegatio
         withdrawer = _withdrawer;
     }
 
-    /// @dev Receive function
+    /// @dev Receive function that will wrap the ether if
+    ///      an address other than the withdrawer sends ether to
+    ///      to the contract. The factory cannot handle ether but
+    ///      has functions to withdraw ERC20 tokens if needed.
     receive() external payable {
         if (msg.sender != address(withdrawer)) {
             weth.deposit{ value: msg.value }();

--- a/contracts/interfaces/external/ICurvePool/ICurvePool.sol
+++ b/contracts/interfaces/external/ICurvePool/ICurvePool.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.11;
 
 /// @title Curve pool interface

--- a/contracts/interfaces/external/ICurvePool/ICurvePool.sol
+++ b/contracts/interfaces/external/ICurvePool/ICurvePool.sol
@@ -1,0 +1,21 @@
+//SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.11;
+
+/// @title Curve pool interface
+interface ICurvePool {
+    function token() external view returns (address);
+
+    function coins(uint256 index) external view returns (address);
+
+    function remove_liquidity_one_coin(
+        uint256 _token_amount,
+        int128 i,
+        uint256 min_amount
+    ) external;
+
+    function remove_liquidity_one_coin(
+        uint256 _token_amount,
+        uint256 i,
+        uint256 min_amount
+    ) external;
+}

--- a/contracts/interfaces/external/ICurvePool/ICurvePoolETH.sol
+++ b/contracts/interfaces/external/ICurvePool/ICurvePoolETH.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.11;
 
 import "./ICurvePool.sol";

--- a/contracts/interfaces/external/ICurvePool/ICurvePoolETH.sol
+++ b/contracts/interfaces/external/ICurvePool/ICurvePoolETH.sol
@@ -1,0 +1,13 @@
+//SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.11;
+
+import "./ICurvePool.sol";
+
+/// @title ETH Curve pool interface
+interface ICurvePoolETH is ICurvePool {
+    function add_liquidity(uint256[2] calldata amounts, uint256 min_mint_amount) external payable;
+
+    function add_liquidity(uint256[3] calldata amounts, uint256 min_mint_amount) external payable;
+
+    function add_liquidity(uint256[4] calldata amounts, uint256 min_mint_amount) external payable;
+}

--- a/contracts/interfaces/external/ICurvePool/ICurvePoolNonETH.sol
+++ b/contracts/interfaces/external/ICurvePool/ICurvePoolNonETH.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.11;
 
 import "./ICurvePool.sol";

--- a/contracts/interfaces/external/ICurvePool/ICurvePoolNonETH.sol
+++ b/contracts/interfaces/external/ICurvePool/ICurvePoolNonETH.sol
@@ -1,0 +1,13 @@
+//SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.11;
+
+import "./ICurvePool.sol";
+
+/// @title non ETH Curve pool interface
+interface ICurvePoolNonETH is ICurvePool {
+    function add_liquidity(uint256[2] calldata amounts, uint256 min_mint_amount) external;
+
+    function add_liquidity(uint256[3] calldata amounts, uint256 min_mint_amount) external;
+
+    function add_liquidity(uint256[4] calldata amounts, uint256 min_mint_amount) external;
+}

--- a/contracts/interfaces/external/IWETH.sol
+++ b/contracts/interfaces/external/IWETH.sol
@@ -11,6 +11,8 @@ interface IWETH {
 
     function transfer(address recipient, uint256 amount) external returns (bool);
 
+    function balanceOf(address recipien) external returns (uint256);
+
     function allowance(address owner, address spender) external view returns (uint256);
 
     function approve(address spender, uint256 amount) external returns (bool);

--- a/contracts/interfaces/external/IYearnVault.sol
+++ b/contracts/interfaces/external/IYearnVault.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.11;
 
 /// @dev Yearn vault interface

--- a/contracts/interfaces/external/IYearnVault.sol
+++ b/contracts/interfaces/external/IYearnVault.sol
@@ -1,0 +1,13 @@
+//SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.11;
+
+/// @dev Yearn vault interface
+interface IYearnVault {
+    function deposit(uint256 _amount) external returns (uint256);
+
+    function withdraw(
+        uint256 _shares,
+        address _recipient,
+        uint256 _maxLoss
+    ) external returns (uint256);
+}

--- a/contracts/libraries/YearnCurveHelpers.sol
+++ b/contracts/libraries/YearnCurveHelpers.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.11;
+
+import "./../interfaces/external/ICurvePool/ICurvePool.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @notice Library for Yearn Curve deposit/withdraw
+library YearnCurveHelpers {
+    using SafeERC20 for IERC20;
+
+    /// @dev Get the array of token amount to send to a
+    ///      Curve 2pool to add liquidity
+    /// @param pool The curve 2pool
+    /// @param token The token to remove from the pool
+    /// @param amount The amount of token to remove from the pool
+    /// @return amounts Array of 2 token amounts sorted by Curve pool token indexes
+    function getAmounts2Coins(
+        ICurvePool pool,
+        address token,
+        uint256 amount
+    ) internal view returns (uint256[2] memory) {
+        if (token == pool.coins(0)) {
+            return [amount, 0];
+        } else {
+            require(token == pool.coins(1), "YCH: INVALID_INPUT_TOKEN");
+            return [0, amount];
+        }
+    }
+
+    /// @dev Get the array of token amount to send to a
+    ///      Curve 3pool to add liquidity
+    /// @param pool The curve 3pool
+    /// @param token The token to remove from the pool
+    /// @param amount The amount of token to remove from the pool
+    /// @return amounts Array of 3 token amounts sorted by Curve pool token indexes
+    function getAmounts3Coins(
+        ICurvePool pool,
+        address token,
+        uint256 amount
+    ) internal view returns (uint256[3] memory) {
+        if (token == pool.coins(0)) {
+            return [amount, 0, 0];
+        } else if (token == pool.coins(1)) {
+            return [0, amount, 0];
+        } else {
+            require(token == pool.coins(2), "YCH: INVALID_INPUT_TOKEN");
+            return [0, 0, amount];
+        }
+    }
+
+    /// @dev Get the array of token amount to send to a
+    ///      Curve 4pool to add liquidity
+    /// @param pool The curve 4pool
+    /// @param token The token to remove from the pool
+    /// @param amount The amount of token to remove from the pool
+    /// @return amounts Array of 4 token amounts sorted by Curve pool token indexes
+    function getAmounts4Coins(
+        ICurvePool pool,
+        address token,
+        uint256 amount
+    ) internal view returns (uint256[4] memory) {
+        if (token == pool.coins(0)) {
+            return [amount, 0, 0, 0];
+        } else if (token == pool.coins(1)) {
+            return [0, amount, 0, 0];
+        } else if (token == pool.coins(2)) {
+            return [0, 0, amount, 0];
+        } else {
+            require(token == pool.coins(3), "YCH: INVALID_INPUT_TOKEN");
+            return [0, 0, 0, amount];
+        }
+    }
+
+    /// @dev Remove liquidity from a Curve pool
+    /// @param pool The Curve pool to remove liquidity from
+    /// @param amount The Curve pool LP token to withdraw
+    /// @param outputToken One of the Curve pool token
+    /// @param poolCoinAmount The amount of token in the Curve pool
+    /// @param signature The signature of the remove_liquidity_one_coin
+    ///                  function to be used to call to the Curve pool
+    function removeLiquidityOneCoin(
+        ICurvePool pool,
+        uint256 amount,
+        address outputToken,
+        uint256 poolCoinAmount,
+        string memory signature
+    ) internal {
+        bool success;
+        if (poolCoinAmount == 2) {
+            // Curve 2pool
+            if (outputToken == pool.coins(0)) {
+                (success, ) = address(pool).call(abi.encodeWithSignature(signature, amount, 0, 0));
+            } else {
+                require(outputToken == pool.coins(1), "YCVO: INVALID_OUTPUT_TOKEN");
+                (success, ) = address(pool).call(abi.encodeWithSignature(signature, amount, 1, 0));
+            }
+        } else if (poolCoinAmount == 3) {
+            // Curve 3pool
+            if (outputToken == pool.coins(0)) {
+                (success, ) = address(pool).call(abi.encodeWithSignature(signature, amount, 0, 0));
+            } else if (outputToken == pool.coins(1)) {
+                (success, ) = address(pool).call(abi.encodeWithSignature(signature, amount, 1, 0));
+            } else {
+                require(outputToken == pool.coins(2), "YCVO: INVALID_OUTPUT_TOKEN");
+                (success, ) = address(pool).call(abi.encodeWithSignature(signature, amount, 2, 0));
+            }
+        } else {
+            // Curve 4pool
+            if (outputToken == pool.coins(0)) {
+                (success, ) = address(pool).call(abi.encodeWithSignature(signature, amount, 0, 0));
+            } else if (outputToken == pool.coins(1)) {
+                (success, ) = address(pool).call(abi.encodeWithSignature(signature, amount, 1, 0));
+            } else if (outputToken == pool.coins(2)) {
+                (success, ) = address(pool).call(abi.encodeWithSignature(signature, amount, 2, 0));
+            } else {
+                require(outputToken == pool.coins(3), "YCVO: INVALID_OUTPUT_TOKEN");
+                (success, ) = address(pool).call(abi.encodeWithSignature(signature, amount, 3, 0));
+            }
+        }
+    }
+
+    /// @dev Get the arrays of obtained token and spent token
+    /// @param inputToken The token spent
+    /// @param inputTokenBalanceBefore The input token balance before
+    /// @param expectedInputAmount The expected amount of input token spent
+    /// @param outputToken The token obtained
+    /// @param outputTokenBalanceBefore The output token balance before
+    /// @param minAmountOut The minimum of output token expected
+    function getOutputAmounts(
+        IERC20 inputToken,
+        uint256 inputTokenBalanceBefore,
+        uint256 expectedInputAmount,
+        IERC20 outputToken,
+        uint256 outputTokenBalanceBefore,
+        uint256 minAmountOut
+    ) internal view returns (uint256[] memory amounts, address[] memory tokens) {
+        uint256 vaultAmount = inputTokenBalanceBefore - inputToken.balanceOf(address(this));
+        require(vaultAmount == expectedInputAmount, "YCVO: INVALID_AMOUNT_WITHDRAWED");
+
+        uint256 tokenAmount = outputToken.balanceOf(address(this)) - outputTokenBalanceBefore;
+        require(tokenAmount != 0, "YCVO: INVALID_AMOUNT_RECEIVED");
+        require(tokenAmount >= minAmountOut, "YCVO: INVALID_AMOUNT_RECEIVED");
+
+        amounts = new uint256[](2);
+        tokens = new address[](2);
+
+        // Output amounts
+        amounts[0] = tokenAmount;
+        amounts[1] = expectedInputAmount;
+
+        // Output token
+        tokens[0] = address(outputToken);
+        tokens[1] = address(inputToken);
+    }
+}

--- a/contracts/libraries/YearnCurveHelpers.sol
+++ b/contracts/libraries/YearnCurveHelpers.sol
@@ -134,8 +134,10 @@ library YearnCurveHelpers {
         uint256 outputTokenBalanceBefore,
         uint256 minAmountOut
     ) internal view returns (uint256[] memory amounts, address[] memory tokens) {
-        uint256 vaultAmount = inputTokenBalanceBefore - inputToken.balanceOf(address(this));
-        require(vaultAmount == expectedInputAmount, "YCVO: INVALID_AMOUNT_WITHDRAWED");
+        require(
+            inputTokenBalanceBefore - inputToken.balanceOf(address(this)) == expectedInputAmount,
+            "YCVO: INVALID_AMOUNT_WITHDRAWED"
+        );
 
         uint256 tokenAmount = outputToken.balanceOf(address(this)) - outputTokenBalanceBefore;
         require(tokenAmount != 0, "YCVO: INVALID_AMOUNT_RECEIVED");

--- a/contracts/libraries/YearnCurveHelpers.sol
+++ b/contracts/libraries/YearnCurveHelpers.sol
@@ -13,7 +13,7 @@ library YearnCurveHelpers {
     /// @param pool The curve 2pool
     /// @param token The token to remove from the pool
     /// @param amount The amount of token to remove from the pool
-    /// @return amounts Array of 2 token amounts sorted by Curve pool token indexes
+    /// @return Array of 2 token amounts sorted by Curve pool token indexes
     function getAmounts2Coins(
         ICurvePool pool,
         address token,

--- a/contracts/operators/Yearn/YearnCurveVaultOperator.sol
+++ b/contracts/operators/Yearn/YearnCurveVaultOperator.sol
@@ -47,7 +47,7 @@ contract YearnCurveVaultOperator {
         withdrawer = _withdrawer;
     }
 
-    /// @notice Add liquidity in a Curve pool that inculdes ETH,
+    /// @notice Add liquidity in a Curve pool that includes ETH,
     ///         deposit the LP token in a Yearn vault and receive
     ///         the Yearn vault shares
     /// @param vault The Yearn vault address to deposit into

--- a/contracts/operators/Yearn/YearnCurveVaultOperator.sol
+++ b/contracts/operators/Yearn/YearnCurveVaultOperator.sol
@@ -330,7 +330,7 @@ contract YearnCurveVaultOperator {
         address outputToken
     ) private {
         uint256 lpTokenBalanceBefore = lpToken.balanceOf(address(this));
-        IYearnVault(vault).withdraw(amount, address(this), 10000);
+        IYearnVault(vault).withdraw(amount, address(this), 10000); // 10000 corresponds to a 100% slippage
 
         YearnCurveHelpers.removeLiquidityOneCoin(
             pool,
@@ -358,7 +358,7 @@ contract YearnCurveVaultOperator {
         address outputToken
     ) private {
         uint256 lpTokenBalanceBefore = lpToken.balanceOf(address(this));
-        IYearnVault(vault).withdraw(amount, address(this), 10000);
+        IYearnVault(vault).withdraw(amount, address(this), 10000); // 10000 corresponds to a 100% slippage
 
         YearnCurveHelpers.removeLiquidityOneCoin(
             pool,

--- a/contracts/operators/Yearn/YearnCurveVaultOperator.sol
+++ b/contracts/operators/Yearn/YearnCurveVaultOperator.sol
@@ -47,7 +47,7 @@ contract YearnCurveVaultOperator {
         withdrawer = _withdrawer;
     }
 
-    /// @notice Add liquidity in a Curve pool that inculde ETH,
+    /// @notice Add liquidity in a Curve pool that inculdes ETH,
     ///         deposit the LP token in a Yearn vault and receive
     ///         the Yearn vault shares
     /// @param vault The Yearn vault address to deposit into

--- a/contracts/operators/Yearn/YearnCurveVaultOperator.sol
+++ b/contracts/operators/Yearn/YearnCurveVaultOperator.sol
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.11;
+
+import "./../../Withdrawer.sol";
+import "./YearnVaultStorage.sol";
+import "./../../libraries/ExchangeHelpers.sol";
+import "./../../libraries/YearnCurveHelpers.sol";
+import "./../../interfaces/external/IYearnVault.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./../../interfaces/external/IWETH.sol";
+import "./../../interfaces/external/ICurvePool/ICurvePoolETH.sol";
+import "./../../interfaces/external/ICurvePool/ICurvePoolNonETH.sol";
+
+/// @title Yearn Curve Vault Operator
+/// @notice Deposit/Withdraw in a Yearn Curve vault.
+contract YearnCurveVaultOperator {
+    YearnVaultStorage public immutable operatorStorage;
+
+    /// @dev ETH address
+    address public immutable eth;
+
+    /// @dev WETH contract
+    IWETH private immutable weth;
+
+    /// @dev Withdrawer
+    Withdrawer private immutable withdrawer;
+
+    constructor(
+        address[] memory vaults,
+        CurvePool[] memory pools,
+        Withdrawer _withdrawer,
+        address _eth,
+        address _weth
+    ) {
+        uint256 vaultsLength = vaults.length;
+        require(vaultsLength == pools.length, "YCVO: INVALID_VAULTS_LENGTH");
+        operatorStorage = new YearnVaultStorage();
+
+        for (uint256 i; i < vaultsLength; i++) {
+            operatorStorage.addVault(vaults[i], pools[i]);
+        }
+
+        operatorStorage.transferOwnership(msg.sender);
+
+        eth = _eth;
+        weth = IWETH(_weth);
+        withdrawer = _withdrawer;
+    }
+
+    /// @notice Add liquidity in a Curve pool that inculde ETH,
+    ///         deposit the LP token in a Yearn vault and receive
+    ///         the Yearn vault shares
+    /// @param vault The Yearn vault address to deposit into
+    /// @param amount The amount of token to add liquidity
+    /// @param minVaultAmount The minimum of Yearn vault shares expected
+    /// @return amounts Array of amounts :
+    ///         - [0] : The vault token received amount
+    ///         - [1] : The token deposited amount
+    /// @return tokens Array of token addresses
+    ///         - [0] : The vault token received address
+    ///         - [1] : The token deposited address
+    function depositETH(
+        address vault,
+        uint256 amount,
+        uint256 minVaultAmount
+    ) external payable returns (uint256[] memory amounts, address[] memory tokens) {
+        require(amount != 0, "YCVO: INVALID_AMOUNT");
+
+        (address pool, uint96 poolCoinAmount, address lpToken) = operatorStorage.vaults(vault);
+        require(pool != address(0), "YCVO: INVALID_VAULT");
+
+        uint256 vaultBalanceBefore = IERC20(vault).balanceOf(address(this));
+        uint256 ethBalanceBefore = weth.balanceOf(address(this));
+
+        _addLiquidityAndDepositETH(vault, ICurvePoolETH(pool), IERC20(lpToken), poolCoinAmount, amount);
+
+        (amounts, tokens) = YearnCurveHelpers.getOutputAmounts(
+            IERC20(address(weth)),
+            ethBalanceBefore,
+            amount,
+            IERC20(vault),
+            vaultBalanceBefore,
+            minVaultAmount
+        );
+    }
+
+    /// @notice Add liquidity in a Curve pool, deposit
+    ///         the LP token in a Yearn vault and receive
+    ///         the Yearn vault shares
+    /// @param vault The Yearn vault address to deposit into
+    /// @param token The token to add liquidity
+    /// @param amount The amount of token to add liquidity
+    /// @param minVaultAmount The minimum of Yearn vault shares expected
+    /// @return amounts Array of amounts :
+    ///         - [0] : The vault token received amount
+    ///         - [1] : The token deposited amount
+    /// @return tokens Array of token addresses
+    ///         - [0] : The vault token received address
+    ///         - [1] : The token deposited address
+    function deposit(
+        address vault,
+        address token,
+        uint256 amount,
+        uint256 minVaultAmount
+    ) external payable returns (uint256[] memory amounts, address[] memory tokens) {
+        require(amount != 0, "YCVO: INVALID_AMOUNT");
+        (address pool, uint96 poolCoinAmount, address lpToken) = operatorStorage.vaults(vault);
+        require(pool != address(0), "YCVO: INVALID_VAULT");
+
+        uint256 vaultBalanceBefore = IERC20(vault).balanceOf(address(this));
+        uint256 tokenBalanceBefore = IERC20(token).balanceOf(address(this));
+
+        _addLiquidityAndDeposit(vault, ICurvePoolNonETH(pool), IERC20(lpToken), poolCoinAmount, token, amount);
+
+        (amounts, tokens) = YearnCurveHelpers.getOutputAmounts(
+            IERC20(token),
+            tokenBalanceBefore,
+            amount,
+            IERC20(vault),
+            vaultBalanceBefore,
+            minVaultAmount
+        );
+    }
+
+    /// @notice Withdraw the LP token from the Yearn vault,
+    ///         remove ETH liquidity from the Curve pool
+    ///         and receive one of the curve pool token
+    /// @param vault The Yearn vault address to withdraw from
+    /// @param amount The amount to withdraw
+    /// @param minAmountOut The minimum of output token expected
+    /// @return amounts Array of amounts :
+    ///         - [0] : The token received amount
+    ///         - [1] : The vault token deposited amount
+    /// @return tokens Array of token addresses
+    ///         - [0] : The token received address
+    ///         - [1] : The vault token deposited address
+    function withdrawETH(
+        address vault,
+        uint256 amount,
+        uint256 minAmountOut
+    ) external payable returns (uint256[] memory amounts, address[] memory tokens) {
+        require(amount != 0, "YCVO: INVALID_AMOUNT");
+
+        (address pool, uint96 poolCoinAmount, address lpToken) = operatorStorage.vaults(vault);
+        require(pool != address(0), "YCVO: INVALID_VAULT");
+
+        uint256 vaultBalanceBefore = IERC20(vault).balanceOf(address(this));
+        uint256 tokenBalanceBefore = weth.balanceOf(address(this));
+
+        _withdrawAndRemoveLiquidity128(vault, amount, ICurvePool(pool), IERC20(lpToken), poolCoinAmount, eth);
+
+        (amounts, tokens) = YearnCurveHelpers.getOutputAmounts(
+            IERC20(vault),
+            vaultBalanceBefore,
+            amount,
+            IERC20(address(weth)),
+            tokenBalanceBefore,
+            minAmountOut
+        );
+    }
+
+    /// @notice Withdraw the LP token from the Yearn vault,
+    ///         remove the liquidity from the Curve pool
+    ///         (using int128 for the curvePool.remove_liquidity_one_coin
+    ///         coin index parameter) and receive one of the
+    ///         curve pool token
+    /// @param vault The Yearn vault address to withdraw from
+    /// @param amount The amount to withdraw
+    /// @param outputToken Output token to receive
+    /// @param minAmountOut The minimum of output token expected
+    /// @return amounts Array of amounts :
+    ///         - [0] : The token received amount
+    ///         - [1] : The vault token deposited amount
+    /// @return tokens Array of token addresses
+    ///         - [0] : The token received address
+    ///         - [1] : The vault token deposited address
+    function withdraw128(
+        address vault,
+        uint256 amount,
+        address outputToken,
+        uint256 minAmountOut
+    ) external payable returns (uint256[] memory amounts, address[] memory tokens) {
+        require(amount != 0, "YCVO: INVALID_AMOUNT");
+
+        (address pool, uint96 poolCoinAmount, address lpToken) = operatorStorage.vaults(vault);
+        require(pool != address(0), "YCVO: INVALID_VAULT");
+
+        uint256 vaultBalanceBefore = IERC20(vault).balanceOf(address(this));
+        uint256 tokenBalanceBefore = IERC20(outputToken).balanceOf(address(this));
+
+        _withdrawAndRemoveLiquidity128(vault, amount, ICurvePool(pool), IERC20(lpToken), poolCoinAmount, outputToken);
+
+        (amounts, tokens) = YearnCurveHelpers.getOutputAmounts(
+            IERC20(vault),
+            vaultBalanceBefore,
+            amount,
+            IERC20(outputToken),
+            tokenBalanceBefore,
+            minAmountOut
+        );
+    }
+
+    /// @notice Withdraw the LP token from the Yearn vault,
+    ///         remove the liquidity from the Curve pool
+    ///         (using uint256 for the curvePool.remove_liquidity_one_coin
+    ///         coin index parameter) and receive one of the
+    ///         curve pool token
+    /// @param vault The Yearn vault address to withdraw from
+    /// @param amount The amount to withdraw
+    /// @param outputToken Output token to receive
+    /// @param minAmountOut The minimum of output token expected
+    /// @return amounts Array of amounts :
+    ///         - [0] : The token received amount
+    ///         - [1] : The vault token deposited amount
+    /// @return tokens Array of token addresses
+    ///         - [0] : The token received address
+    ///         - [1] : The vault token deposited address
+    function withdraw256(
+        address vault,
+        uint256 amount,
+        address outputToken,
+        uint256 minAmountOut
+    ) external payable returns (uint256[] memory amounts, address[] memory tokens) {
+        require(amount != 0, "YCVO: INVALID_AMOUNT");
+
+        (address pool, uint96 poolCoinAmount, address lpToken) = operatorStorage.vaults(vault);
+        require(pool != address(0), "YCVO: INVALID_VAULT");
+
+        uint256 vaultBalanceBefore = IERC20(vault).balanceOf(address(this));
+        uint256 tokenBalanceBefore = IERC20(outputToken).balanceOf(address(this));
+
+        _withdrawAndRemoveLiquidity256(
+            vault,
+            amount,
+            ICurvePoolNonETH(pool),
+            IERC20(lpToken),
+            poolCoinAmount,
+            outputToken
+        );
+
+        (amounts, tokens) = YearnCurveHelpers.getOutputAmounts(
+            IERC20(vault),
+            vaultBalanceBefore,
+            amount,
+            IERC20(outputToken),
+            tokenBalanceBefore,
+            minAmountOut
+        );
+    }
+
+    /// @dev  Add liquidity in a Curve pool with ETH and deposit
+    ///       the LP token in a Yearn vault
+    /// @param vault The Yearn vault address to deposit into
+    /// @param pool The curve pool to add liquitiy in
+    /// @param lpToken The curve pool LP token
+    /// @param poolCoinAmount The number of token in the Curve pool
+    /// @param amount ETH amount to add in the Curve pool
+    function _addLiquidityAndDepositETH(
+        address vault,
+        ICurvePoolETH pool,
+        IERC20 lpToken,
+        uint256 poolCoinAmount,
+        uint256 amount
+    ) private {
+        uint256 lpTokenBalanceBefore = lpToken.balanceOf(address(this));
+        ExchangeHelpers.setMaxAllowance(IERC20(address(weth)), address(withdrawer));
+
+        // withdraw ETH from WETH
+        withdrawer.withdraw(amount);
+
+        if (poolCoinAmount == 2) {
+            pool.add_liquidity{ value: amount }(YearnCurveHelpers.getAmounts2Coins(pool, eth, amount), 0);
+        } else if (poolCoinAmount == 3) {
+            pool.add_liquidity{ value: amount }(YearnCurveHelpers.getAmounts3Coins(pool, eth, amount), 0);
+        } else {
+            pool.add_liquidity{ value: amount }(YearnCurveHelpers.getAmounts4Coins(pool, eth, amount), 0);
+        }
+
+        uint256 lpTokenToDeposit = lpToken.balanceOf(address(this)) - lpTokenBalanceBefore;
+        ExchangeHelpers.setMaxAllowance(lpToken, vault);
+        IYearnVault(vault).deposit(lpTokenToDeposit);
+    }
+
+    /// @dev  Add liquidity in a Curve pool and deposit
+    ///       the LP token in a Yearn vault
+    /// @param vault The Yearn vault address to deposit into
+    /// @param pool The curve pool to add liquitiy in
+    /// @param lpToken The curve pool lpToken
+    /// @param poolCoinAmount The number of token in the Curve pool
+    /// @param token Token to add in the Curve pool liquidity
+    /// @param amount Token amount to add in the Curve pool
+    function _addLiquidityAndDeposit(
+        address vault,
+        ICurvePoolNonETH pool,
+        IERC20 lpToken,
+        uint256 poolCoinAmount,
+        address token,
+        uint256 amount
+    ) private {
+        uint256 lpTokenBalanceBefore = lpToken.balanceOf(address(this));
+        ExchangeHelpers.setMaxAllowance(IERC20(token), address(pool));
+
+        if (poolCoinAmount == 2) {
+            pool.add_liquidity(YearnCurveHelpers.getAmounts2Coins(pool, token, amount), 0);
+        } else if (poolCoinAmount == 3) {
+            pool.add_liquidity(YearnCurveHelpers.getAmounts3Coins(pool, token, amount), 0);
+        } else {
+            pool.add_liquidity(YearnCurveHelpers.getAmounts4Coins(pool, token, amount), 0);
+        }
+
+        uint256 lpTokenToDeposit = lpToken.balanceOf(address(this)) - lpTokenBalanceBefore;
+        ExchangeHelpers.setMaxAllowance(lpToken, vault);
+        IYearnVault(vault).deposit(lpTokenToDeposit);
+    }
+
+    /// @dev Withdraw the LP token from the Yearn vault and
+    ///      remove the liquidity from the Curve pool
+    /// @param vault The Yearn vault address to withdraw from
+    /// @param amount The amount to withdraw
+    /// @param pool The Curve pool to remove liquitiy from
+    /// @param lpToken The Curve pool LP token
+    /// @param poolCoinAmount The number of token in the Curve pool
+    /// @param outputToken Output token to receive
+    function _withdrawAndRemoveLiquidity256(
+        address vault,
+        uint256 amount,
+        ICurvePool pool,
+        IERC20 lpToken,
+        uint256 poolCoinAmount,
+        address outputToken
+    ) private {
+        uint256 lpTokenBalanceBefore = lpToken.balanceOf(address(this));
+        IYearnVault(vault).withdraw(amount, address(this), 10000);
+
+        YearnCurveHelpers.removeLiquidityOneCoin(
+            pool,
+            lpToken.balanceOf(address(this)) - lpTokenBalanceBefore,
+            outputToken,
+            poolCoinAmount,
+            "remove_liquidity_one_coin(uint256,uint256,uint256)"
+        );
+    }
+
+    /// @dev Withdraw the LP token from the Yearn vault and
+    ///      remove the liquidity from the Curve pool
+    /// @param vault The Yearn vault address to withdraw from
+    /// @param amount The amount to withdraw
+    /// @param pool The Curve pool to remove liquitiy from
+    /// @param lpToken The Curve pool LP token
+    /// @param poolCoinAmount The number of token in the Curve pool
+    /// @param outputToken Output token to receive
+    function _withdrawAndRemoveLiquidity128(
+        address vault,
+        uint256 amount,
+        ICurvePool pool,
+        IERC20 lpToken,
+        uint256 poolCoinAmount,
+        address outputToken
+    ) private {
+        uint256 lpTokenBalanceBefore = lpToken.balanceOf(address(this));
+        IYearnVault(vault).withdraw(amount, address(this), 10000);
+
+        YearnCurveHelpers.removeLiquidityOneCoin(
+            pool,
+            lpToken.balanceOf(address(this)) - lpTokenBalanceBefore,
+            outputToken,
+            poolCoinAmount,
+            "remove_liquidity_one_coin(uint256,int128,uint256)"
+        );
+    }
+}

--- a/contracts/operators/Yearn/YearnVaultStorage.sol
+++ b/contracts/operators/Yearn/YearnVaultStorage.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.11;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+struct CurvePool {
+    address poolAddress;
+    uint96 poolCoinAmount;
+    address lpToken;
+}
+
+/// @title YearnVaultStorage storage contract
+contract YearnVaultStorage is Ownable {
+    /// @dev Emitted when a vault is added
+    /// @param vault The vault address
+    /// @param pool The underlying CurvePool
+    event VaultAdded(address vault, CurvePool pool);
+
+    /// @dev Emitted when a vault is removed
+    /// @param vault The removed vault address
+    event VaultRemoved(address vault);
+
+    /// @dev Map of vault address with underlying CurvePool
+    mapping(address => CurvePool) public vaults;
+
+    /// @notice Add a Yearn single asset vault
+    /// @param vault The vault address
+    /// @param pool The underlying CurvePool (used to add liquidity)
+    function addVault(address vault, CurvePool calldata pool) external onlyOwner {
+        require(vault != address(0), "YVS: INVALID_VAULT_ADDRESS");
+        require(pool.poolAddress != address(0), "YVS: INVALID_POOL_ADDRESS");
+        require(vaults[vault].poolAddress == address(0), "YVS: ALREADY_EXISTENT_VAULT");
+        vaults[vault] = pool;
+        emit VaultAdded(vault, pool);
+    }
+
+    /// @notice Remove a Yearn vault
+    /// @param vault The vault address to remove
+    function removeVault(address vault) external onlyOwner {
+        require(vaults[vault].poolAddress != address(0), "YVS: NON_EXISTENT_VAULT");
+        delete vaults[vault];
+        emit VaultRemoved(vault);
+    }
+}

--- a/contracts/operators/Yearn/YearnVaultStorage.sol
+++ b/contracts/operators/Yearn/YearnVaultStorage.sol
@@ -23,7 +23,7 @@ contract YearnVaultStorage is Ownable {
     /// @dev Map of vault address with underlying CurvePool
     mapping(address => CurvePool) public vaults;
 
-    /// @notice Add a Yearn single asset vault
+    /// @notice Add a Yearn Curve vault
     /// @param vault The vault address
     /// @param pool The underlying CurvePool (used to add liquidity)
     function addVault(address vault, CurvePool calldata pool) external onlyOwner {

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -330,7 +330,7 @@ export function getUniAndKncWithETHOrders(
     ];
 }
 
-// Create a Deposit order in yearn
+// Create a non-ETH Deposit order in yearn
 export function getYearnCurveDepositOrder(context: FactoryAndOperatorsForkingETHFixture, yearnVaultAddress: string, tokenToDeposit: string, amountToDeposit: BigNumber, minVaultAmount?: BigNumber) {
     return [
         buildOrderStruct(context.yearnVaultDepositOperatorNameBytes32, yearnVaultAddress, [
@@ -342,7 +342,7 @@ export function getYearnCurveDepositOrder(context: FactoryAndOperatorsForkingETH
     ];
 }
 
-// Create a Deposit order in yearn
+// Create an ETH Deposit order in yearn
 export function getYearnCurveDepositETHOrder(context: FactoryAndOperatorsForkingETHFixture, yearnVaultAddress: string, amountToDeposit: BigNumber, minVaultAmount?: BigNumber) {
     return [
         buildOrderStruct(context.yearnVaultDepositETHOperatorNameBytes32, yearnVaultAddress, [
@@ -353,7 +353,7 @@ export function getYearnCurveDepositETHOrder(context: FactoryAndOperatorsForking
     ];
 }
 
-// Create a Withdraw order in yearn
+// Create a Withdraw256 order in yearn (for Curve pool that require a uint256 index param in the function remove_liquidity_one_coin)
 export function getYearnCurveWithdraw256Order(context: FactoryAndOperatorsForkingETHFixture, yearnVaultAddress: string, amountToWithdraw: BigNumber, outputToken: string, minAmountOut?: BigNumber) {
     return [
         buildOrderStruct(context.yearnVaultWithdraw256OperatorNameBytes32, yearnVaultAddress, [
@@ -365,7 +365,7 @@ export function getYearnCurveWithdraw256Order(context: FactoryAndOperatorsForkin
     ];
 }
 
-// Create a Withdraw order in yearn
+// Create a Withdraw128 order in yearn (for Curve pool that require a int128 index param in the function remove_liquidity_one_coin)
 export function getYearnCurveWithdraw128Order(context: FactoryAndOperatorsForkingETHFixture, yearnVaultAddress: string, amountToWithdraw: BigNumber, outputToken: string, minAmountOut?: BigNumber) {
     return [
         buildOrderStruct(context.yearnVaultWithdraw128OperatorNameBytes32, yearnVaultAddress, [

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,8 +1,11 @@
 import { ethers } from "hardhat";
-import { BigNumber } from "ethers";
+import { BigNumber, Wallet } from "ethers";
+import { string } from "hardhat/internal/core/params/argumentTypes";
 const w3utils = require("web3-utils");
+const abiCoder = new ethers.utils.AbiCoder();
 
 export const appendDecimals = (amount: number) => ethers.utils.parseEther(amount.toString());
+export const append6Decimals = (amount: number) => { return BigNumber.from(amount).mul(10 ** 6) };
 
 export const getETHSpentOnGas = async (tx: any) => {
     const receipt = await tx.wait();
@@ -20,4 +23,20 @@ export const fromBytes32 = (key: string) => w3utils.hexToAscii(key);
 
 export function getExpectedFees(amount: BigNumber) {
     return amount.div(100);
+}
+
+export const setAllowance = async (signer: Wallet, contract: string, spender: string, amount: BigNumber) => {
+    const data =
+        ethers.utils.keccak256(
+            ethers.utils.toUtf8Bytes("approve(address,uint256)")
+        ).slice(0, 10) +
+        abiCoder.encode(
+            ["address", "uint256"],
+            [spender, amount]
+        ).slice(2, 130)
+
+    await signer.sendTransaction({
+        to: contract,
+        data: data
+    })
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -5,7 +5,7 @@ const w3utils = require("web3-utils");
 const abiCoder = new ethers.utils.AbiCoder();
 
 export const appendDecimals = (amount: number) => ethers.utils.parseEther(amount.toString());
-export const append6Decimals = (amount: number) => { return BigNumber.from(amount).mul(10 ** 6) };
+export const append6Decimals = (amount: number) => { return BigNumber.from(amount).mul(10 ** 6) }; // needed for EURT that has 6 decimals
 
 export const getETHSpentOnGas = async (tx: any) => {
     const receipt = await tx.wait();

--- a/test/shared/impersonnate.ts
+++ b/test/shared/impersonnate.ts
@@ -1,0 +1,55 @@
+import { BigNumber, Wallet } from "ethers";
+import { ethers, network } from "hardhat";
+
+const abiCoder = new ethers.utils.AbiCoder();
+
+
+export const impersonnate = async (address: string) => {
+    await network.provider.request({
+        method: "hardhat_impersonateAccount",
+        params: [address],
+    })
+
+    return await ethers.getSigner(address)
+}
+
+export const addUsdcBalanceToBSC = async (receiver: Wallet, amount: BigNumber) => {
+    const usdcWhale: string = "0xf977814e90da44bfa03b6295a0616a897441acec"
+    const usdcContract: string = "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d"
+    const signer = await impersonnate(usdcWhale)
+
+    const data =
+        ethers.utils.keccak256(
+            ethers.utils.toUtf8Bytes("transfer(address,uint256)")
+        ).slice(0, 10) +
+        abiCoder.encode(
+            ["address", "uint256"],
+            [receiver.address, amount]
+        ).slice(2, 130)
+
+    await signer.sendTransaction({
+        from: signer.address,
+        to: usdcContract,
+        data: data
+    })
+}
+
+export const addEurtBalanceToETH = async (receiver: Wallet, amount: BigNumber) => {
+    const eurtWhale: string = "0x5754284f345afc66a98fbb0a0afe71e0f007b949"
+    const eurtContract: string = "0xC581b735A1688071A1746c968e0798D642EDE491"
+    const signer = await impersonnate(eurtWhale)
+
+    const data =
+        ethers.utils.keccak256(
+            ethers.utils.toUtf8Bytes("transfer(address,uint256)")
+        ).slice(0, 10) +
+        abiCoder.encode(
+            ["address", "uint256"],
+            [receiver.address, amount]
+        ).slice(2, 130)
+    await signer.sendTransaction({
+        from: signer.address,
+        to: eurtContract,
+        data: data
+    })
+}

--- a/test/shared/provider.ts
+++ b/test/shared/provider.ts
@@ -12,5 +12,7 @@ export const expect = chai.expect;
 export const assert = chai.assert;
 
 export const describeOnBscFork =
-    !config.networks.hardhat.forking.enabled && process.env.FORK_CHAINID === "56" ? describe.skip : describe;
+    config.networks.hardhat.forking.enabled && process.env.FORK_CHAINID === "56" ? describe : describe.skip;
+export const describeOnEthFork =
+    config.networks.hardhat.forking.enabled && process.env.FORK_CHAINID === "1" ? describe : describe.skip;
 export const describeWithoutFork = config.networks.hardhat.forking.enabled ? describe.skip : describe;

--- a/test/unit/YearnCurveVaultOperator.unit.ts
+++ b/test/unit/YearnCurveVaultOperator.unit.ts
@@ -96,7 +96,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
     });
 
     describe("deposit()", () => {
-        it("Should revert if amount to deposit is zero", async () => { // Done
+        it("Should revert if amount to deposit is zero", async () => {
             // All the amounts for this test
             const ethToDeposit = appendDecimals(1);
             const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
@@ -114,7 +114,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
-        it("Should revert if deposit more than available", async () => { // Done, fail at add_liquidity
+        it("Should revert if deposit more than available", async () => {
             // All the amounts for this test
             const ethToDeposit = appendDecimals(1);
             const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
@@ -132,7 +132,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
-        it("Should revert if vault is not added in Operator Storage", async () => { // Done
+        it("Should revert if vault is not added in Operator Storage", async () => {
             // All the amounts for this test
             const ethToDeposit = appendDecimals(1);
             const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
@@ -152,7 +152,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
-        it("Should revert if token is not in Curve pool", async () => { // Done
+        it("Should revert if token is not in Curve pool", async () => {
             // All the amounts for this test
             const ethToDeposit = appendDecimals(1);
             const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
@@ -170,7 +170,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
-        it("Should revert if minVaultAmount is not respected", async () => { // Done
+        it("Should revert if minVaultAmount is not respected", async () => {
             // All the amounts for this test
             const ethToDeposit = appendDecimals(1);
             const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
@@ -188,56 +188,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
-        it("Create with ETH and Deposit (uint256) in yearn 3crypto with WETH", async () => {
-            // All the amounts for this test
-            const ethToDeposit = appendDecimals(1);
-            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
-
-            const ethBalanceBefore = await context.user1.getBalance();
-
-            // Orders to Deposit in yearn
-            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositOrder(context, context.yearnVaultAddresses.triCryptoVault, context.WETH.address, ethToDeposit);
-
-            // User1 creates the portfolio/NFT
-            const tx = await context.nestedFactory
-                .connect(context.user1)
-                .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
-                    value: ethToDepositAndFees,
-                });
-
-            // Get the transaction fees
-            const txFees = await tx.wait().then(value => value.gasUsed.mul(value.effectiveGasPrice));
-
-            // User1 must be the owner of NFT n°1
-            expect(await context.nestedAsset.ownerOf(1)).to.be.equal(context.user1.address);
-
-            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
-            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.triCryptoVault);
-
-            //  Tokens in vault
-            const vaultBalanceReserve = await vault.balanceOf(context.nestedReserve.address);
-            expect(vaultBalanceReserve).to.not.be.equal(BIG_NUMBER_ZERO);
-
-            expect(await context.user1.getBalance()).to.be.equal(ethBalanceBefore.sub(ethToDepositAndFees).sub(txFees));
-
-            // The FeeSplitter must receive the right fee amount
-            expect(await context.WETH.balanceOf(context.feeSplitter.address)).to.be.equal(
-                getExpectedFees(ethToDeposit),
-            );
-
-            const expectedNfts = [
-                {
-                    id: BigNumber.from(1),
-                    assets: [{ token: context.yearnVaultAddresses.triCryptoVault, qty: vaultBalanceReserve }],
-                },
-            ];
-
-            const nfts = await context.nestedAssetBatcher.getNfts(context.user1.address);
-
-            expect(JSON.stringify(utils.cleanResult(nfts))).to.equal(JSON.stringify(utils.cleanResult(expectedNfts)));
-        });
-
-        it("Create with ETH and Deposit (int128) in yearn 3crypto with WETH", async () => {
+        it("Create with ETH and Deposit in yearn 3crypto with WETH", async () => {
             // All the amounts for this test
             const ethToDeposit = appendDecimals(1);
             const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
@@ -288,7 +239,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
     });
 
     describe("depositETH()", async () => {
-        it("Should revert if amount to deposit is zero", async () => { // Done
+        it("Should revert if amount to deposit is zero", async () => {
             // All the amounts for this test
             const ethToDeposit = appendDecimals(1);
             const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
@@ -305,7 +256,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     }),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
-        it("Should revert if deposit more than available", async () => { // Done, fail at withdrawer
+        it("Should revert if deposit more than available", async () => {
             // All the amounts for this test
             const ethToDeposit = appendDecimals(1);
             const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
@@ -322,7 +273,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     }),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
-        it("Should revert if vault is not added in Operator Storage", async () => { // Done
+        it("Should revert if vault is not added in Operator Storage", async () => {
             // All the amounts for this test
             const ethToDeposit = appendDecimals(1);
             const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
@@ -341,7 +292,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     }),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
-        it("Should revert if minVaultAmount is not respected", async () => { // Done
+        it("Should revert if minVaultAmount is not respected", async () => {
             // All the amounts for this test
             const ethToDeposit = appendDecimals(1);
             const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
@@ -425,7 +376,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                 });
 
         });
-        it("Should revert if amount to withdraw is zero", async () => { // Done
+        it("Should revert if amount to withdraw is zero", async () => {
             const mockERC20Factory = await ethers.getContractFactory("MockERC20");
             const vault = mockERC20Factory.attach(context.yearnVaultAddresses.triCryptoVault);
 
@@ -443,7 +394,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
-        it("Should revert if withdraw more than available", async () => { // Done, fail at withdraw
+        it("Should revert if withdraw more than available", async () => {
             const mockERC20Factory = await ethers.getContractFactory("MockERC20");
             const vault = mockERC20Factory.attach(context.yearnVaultAddresses.triCryptoVault);
 
@@ -461,7 +412,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
-        it("Should revert if vault is not added in Operator Storage", async () => { // Done
+        it("Should revert if vault is not added in Operator Storage", async () => {
             // Orders to withdraw from yearn curve vault
             let orders: utils.OrderStruct[] = utils.getYearnCurveWithdraw256Order(context, context.yearnVaultAddresses.nonWhitelistedVault, BigNumber.from(100), context.WETH.address);
 
@@ -474,7 +425,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
-        it("Should revert if token is not in Curve pool", async () => { // Done
+        it("Should revert if token is not in Curve pool", async () => {
             const mockERC20Factory = await ethers.getContractFactory("MockERC20");
             const vault = mockERC20Factory.attach(context.yearnVaultAddresses.triCryptoVault);
 
@@ -492,7 +443,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
-        it("Should revert if minAmountOut is not respected", async () => { // Done
+        it("Should revert if minAmountOut is not respected", async () => {
             const mockERC20Factory = await ethers.getContractFactory("MockERC20");
             const vault = mockERC20Factory.attach(context.yearnVaultAddresses.triCryptoVault);
 
@@ -526,7 +477,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
             expect(await vault.balanceOf(context.nestedFactory.address)).to.be.equal(BIG_NUMBER_ZERO);
 
             /*
-             * I can't predict the WETH received in the FeeSplitter.
+             * WETH received by the FeeSplitter cannot be predicted.
              * It should be greater than 0.01 WETH, but sub 1% to allow a margin of error
              */
             expect(await context.WETH.balanceOf(context.feeSplitter.address)).to.be.gt(
@@ -551,7 +502,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     value: 0,
                 });
         });
-        it("Should revert if amount to withdraw is zero", async () => { // Done
+        it("Should revert if amount to withdraw is zero", async () => {
             const mockERC20Factory = await ethers.getContractFactory("MockERC20");
             const vault = mockERC20Factory.attach(context.yearnVaultAddresses.threeEurVault);
 
@@ -569,7 +520,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
-        it("Should revert if withdraw more than available", async () => { // Done, fail at withdraw
+        it("Should revert if withdraw more than available", async () => {
             const mockERC20Factory = await ethers.getContractFactory("MockERC20");
             const vault = mockERC20Factory.attach(context.yearnVaultAddresses.threeEurVault);
 
@@ -600,7 +551,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
-        it("Should revert if token is not in Curve pool", async () => { // Done
+        it("Should revert if token is not in Curve pool", async () => {
             const mockERC20Factory = await ethers.getContractFactory("MockERC20");
             const vault = mockERC20Factory.attach(context.yearnVaultAddresses.threeEurVault);
 
@@ -618,7 +569,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
-        it("Should revert if minAmountOut is not respected", async () => { // Done
+        it("Should revert if minAmountOut is not respected", async () => {
             const mockERC20Factory = await ethers.getContractFactory("MockERC20");
             const vault = mockERC20Factory.attach(context.yearnVaultAddresses.threeEurVault);
 
@@ -654,7 +605,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
             expect(await vault.balanceOf(context.nestedFactory.address)).to.be.equal(BIG_NUMBER_ZERO);
 
             /*
-             * I can't predict the WETH received in the FeeSplitter.
+             * WETH received by the FeeSplitter cannot be predicted.
              * It should be greater than 0.01 WETH, but sub 1% to allow a margin of error
              */
             expect(await eurt.balanceOf(context.feeSplitter.address)).to.be.gt(
@@ -681,7 +632,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     value: ethToDepositAndFees,
                 });
         });
-        it("Should revert if amount to withdraw is zero", async () => { // Done
+        it("Should revert if amount to withdraw is zero", async () => {
             // Orders to withdraw from yearn curve vault
             let orders: utils.OrderStruct[] = utils.getYearnCurveWithdrawETHOrder(context, context.yearnVaultAddresses.alEthVault, BIG_NUMBER_ZERO);
 
@@ -694,7 +645,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
-        it("Should revert if withdraw more than available", async () => { // Done
+        it("Should revert if withdraw more than available", async () => {
             const mockERC20Factory = await ethers.getContractFactory("MockERC20");
             const vault = mockERC20Factory.attach(context.yearnVaultAddresses.alEthVault);
 
@@ -712,7 +663,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
-        it("Should revert if vault is not added in Operator Storage", async () => { // Done
+        it("Should revert if vault is not added in Operator Storage", async () => {
             // Orders to withdraw from yearn curve vault
             let orders: utils.OrderStruct[] = utils.getYearnCurveWithdrawETHOrder(context, context.yearnVaultAddresses.nonWhitelistedVault, BigNumber.from(100));
 
@@ -725,7 +676,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
-        it("Should revert if minAmountOut is not respected", async () => { // Done
+        it("Should revert if minAmountOut is not respected", async () => {
             const mockERC20Factory = await ethers.getContractFactory("MockERC20");
             const vault = mockERC20Factory.attach(context.yearnVaultAddresses.alEthVault);
 
@@ -759,7 +710,7 @@ describeOnEthFork("YearnCurveVaultOperator", () => {
             expect(await vault.balanceOf(context.nestedFactory.address)).to.be.equal(BIG_NUMBER_ZERO);
 
             /*
-             * I can't predict the WETH received in the FeeSplitter.
+             * WETH received by the FeeSplitter cannot be predicted.
              * It should be greater than 0.01 WETH, but sub 1% to allow a margin of error
              */
             expect(await context.WETH.balanceOf(context.feeSplitter.address)).to.be.gt(

--- a/test/unit/YearnCurveVaultOperator.unit.ts
+++ b/test/unit/YearnCurveVaultOperator.unit.ts
@@ -1,0 +1,770 @@
+import { LoadFixtureFunction } from "../types";
+import { EURT, FactoryAndOperatorsForkingETHFixture, factoryAndOperatorsForkingETHFixture, USDCEth } from "../shared/fixtures";
+import { createFixtureLoader, describeOnEthFork, expect, provider } from "../shared/provider";
+import { BigNumber, Wallet } from "ethers";
+import { append6Decimals, appendDecimals, BIG_NUMBER_ZERO, getExpectedFees, UINT256_MAX } from "../helpers";
+import * as utils from "../../scripts/utils";
+import { ethers } from "hardhat";
+
+let loadFixture: LoadFixtureFunction;
+
+describeOnEthFork("YearnCurveVaultOperator", () => {
+    let context: FactoryAndOperatorsForkingETHFixture;
+    const ETH = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+    before("loader", async () => {
+        loadFixture = createFixtureLoader(provider.getWallets(), provider);
+    });
+
+    beforeEach("create fixture loader", async () => {
+        context = await loadFixture(factoryAndOperatorsForkingETHFixture);
+    });
+
+    it("deploys and has an address", async () => {
+        expect(context.yearnCurveVaultOperator.address).to.be.a.string;
+    });
+
+    describe("addVault()", () => {
+        it("Should revert if vault is address zero", async () => {
+            const vaultToAdd = ethers.constants.AddressZero;
+            const poolToAdd = Wallet.createRandom().address;
+            await expect(
+                context.yearnVaultStorage.connect(context.masterDeployer).addVault(vaultToAdd, {
+                    poolAddress: poolToAdd,
+                    poolCoinAmount: 1,
+                    lpToken: poolToAdd
+                }),
+            ).to.be.revertedWith("YVS: INVALID_VAULT_ADDRESS");
+        });
+
+        it("Should revert if already existent vault", async () => {
+            const vaultToAdd = Wallet.createRandom().address;
+            const poolToAdd = Wallet.createRandom().address;
+            await context.yearnVaultStorage.connect(context.masterDeployer).addVault(vaultToAdd, {
+                poolAddress: poolToAdd,
+                poolCoinAmount: 1,
+                lpToken: poolToAdd
+            });
+
+            await expect(
+                context.yearnVaultStorage.connect(context.masterDeployer).addVault(vaultToAdd, {
+                    poolAddress: poolToAdd,
+                    poolCoinAmount: 1,
+                    lpToken: poolToAdd
+                }),
+            ).to.be.revertedWith("YVS: ALREADY_EXISTENT_VAULT");
+        });
+
+        it("Should add new vault", async () => {
+            const vaultToAdd = Wallet.createRandom().address;
+            const poolToAdd = Wallet.createRandom().address;
+            const poolCoinAmount = 1;
+            await context.yearnVaultStorage.connect(context.masterDeployer).addVault(vaultToAdd, {
+                poolAddress: poolToAdd,
+                poolCoinAmount,
+                lpToken: poolToAdd
+            });
+
+            expect(await (await context.yearnVaultStorage.vaults(vaultToAdd)).poolAddress).to.equal(poolToAdd);
+            expect(await (await context.yearnVaultStorage.vaults(vaultToAdd)).poolCoinAmount).to.equal(poolCoinAmount);
+
+        });
+    });
+
+    describe("removeVault()", () => {
+        it("Should revert if non-existent vault", async () => {
+            const vaultToRemove = Wallet.createRandom().address;
+
+            await expect(
+                context.yearnVaultStorage.connect(context.masterDeployer).removeVault(vaultToRemove),
+            ).to.be.revertedWith("YVS: NON_EXISTENT_VAULT");
+        });
+
+        it("Should remove vault", async () => {
+            const vaultToAdd = Wallet.createRandom().address;
+            const poolToAdd = Wallet.createRandom().address;
+            await context.yearnVaultStorage.connect(context.masterDeployer).addVault(vaultToAdd, {
+                poolAddress: poolToAdd,
+                poolCoinAmount: 1,
+                lpToken: poolToAdd
+            });
+
+            await context.yearnVaultStorage.connect(context.masterDeployer).removeVault(vaultToAdd);
+
+            expect(await (await context.yearnVaultStorage.vaults(vaultToAdd)).poolAddress).to.equal(ethers.constants.AddressZero);
+        });
+    });
+
+    describe("deposit()", () => {
+        it("Should revert if amount to deposit is zero", async () => { // Done
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            // Orders to deposit in yearn with amount 0
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositOrder(context, context.yearnVaultAddresses.triCryptoVault, context.WETH.address, BIG_NUMBER_ZERO);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                        value: ethToDepositAndFees,
+                    }),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+
+        it("Should revert if deposit more than available", async () => { // Done, fail at add_liquidity
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            // Orders to deposit in yearn with "initial amount x 2" (more than msg.value)
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositOrder(context, context.yearnVaultAddresses.triCryptoVault, context.WETH.address, ethToDepositAndFees.mul(2));
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                        value: ethToDepositAndFees,
+                    }),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+
+        it("Should revert if vault is not added in Operator Storage", async () => { // Done
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            const notWhitelistedVault = Wallet.createRandom().address;
+
+            // Orders to Deposit in yearn
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositOrder(context, notWhitelistedVault, context.WETH.address, ethToDeposit);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                        value: ethToDepositAndFees,
+                    }),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+
+        it("Should revert if token is not in Curve pool", async () => { // Done
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            // Orders to Deposit in yearn
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositOrder(context, context.yearnVaultAddresses.triCryptoVault, USDCEth, ethToDeposit);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                        value: ethToDepositAndFees,
+                    }),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+
+        it("Should revert if minVaultAmount is not respected", async () => { // Done
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            // Orders to Deposit in yearn
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositOrder(context, context.yearnVaultAddresses.triCryptoVault, context.WETH.address, ethToDeposit, UINT256_MAX);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                        value: ethToDepositAndFees,
+                    }),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+
+        it("Create with ETH and Deposit (uint256) in yearn 3crypto with WETH", async () => {
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            const ethBalanceBefore = await context.user1.getBalance();
+
+            // Orders to Deposit in yearn
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositOrder(context, context.yearnVaultAddresses.triCryptoVault, context.WETH.address, ethToDeposit);
+
+            // User1 creates the portfolio/NFT
+            const tx = await context.nestedFactory
+                .connect(context.user1)
+                .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                    value: ethToDepositAndFees,
+                });
+
+            // Get the transaction fees
+            const txFees = await tx.wait().then(value => value.gasUsed.mul(value.effectiveGasPrice));
+
+            // User1 must be the owner of NFT n°1
+            expect(await context.nestedAsset.ownerOf(1)).to.be.equal(context.user1.address);
+
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.triCryptoVault);
+
+            //  Tokens in vault
+            const vaultBalanceReserve = await vault.balanceOf(context.nestedReserve.address);
+            expect(vaultBalanceReserve).to.not.be.equal(BIG_NUMBER_ZERO);
+
+            expect(await context.user1.getBalance()).to.be.equal(ethBalanceBefore.sub(ethToDepositAndFees).sub(txFees));
+
+            // The FeeSplitter must receive the right fee amount
+            expect(await context.WETH.balanceOf(context.feeSplitter.address)).to.be.equal(
+                getExpectedFees(ethToDeposit),
+            );
+
+            const expectedNfts = [
+                {
+                    id: BigNumber.from(1),
+                    assets: [{ token: context.yearnVaultAddresses.triCryptoVault, qty: vaultBalanceReserve }],
+                },
+            ];
+
+            const nfts = await context.nestedAssetBatcher.getNfts(context.user1.address);
+
+            expect(JSON.stringify(utils.cleanResult(nfts))).to.equal(JSON.stringify(utils.cleanResult(expectedNfts)));
+        });
+
+        it("Create with ETH and Deposit (int128) in yearn 3crypto with WETH", async () => {
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            const ethBalanceBefore = await context.user1.getBalance();
+
+            // Orders to Deposit in yearn
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositOrder(context, context.yearnVaultAddresses.triCryptoVault, context.WETH.address, ethToDeposit);
+
+            // User1 creates the portfolio/NFT
+            const tx = await context.nestedFactory
+                .connect(context.user1)
+                .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                    value: ethToDepositAndFees,
+                });
+
+            // Get the transaction fees
+            const txFees = await tx.wait().then(value => value.gasUsed.mul(value.effectiveGasPrice));
+
+            // User1 must be the owner of NFT n°1
+            expect(await context.nestedAsset.ownerOf(1)).to.be.equal(context.user1.address);
+
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.triCryptoVault);
+
+            //  Tokens in vault
+            const vaultBalanceReserve = await vault.balanceOf(context.nestedReserve.address);
+            expect(vaultBalanceReserve).to.not.be.equal(BIG_NUMBER_ZERO);
+
+            expect(await context.user1.getBalance()).to.be.equal(ethBalanceBefore.sub(ethToDepositAndFees).sub(txFees));
+
+            // The FeeSplitter must receive the right fee amount
+            expect(await context.WETH.balanceOf(context.feeSplitter.address)).to.be.equal(
+                getExpectedFees(ethToDeposit),
+            );
+
+            const expectedNfts = [
+                {
+                    id: BigNumber.from(1),
+                    assets: [{ token: context.yearnVaultAddresses.triCryptoVault, qty: vaultBalanceReserve }],
+                },
+            ];
+
+            const nfts = await context.nestedAssetBatcher.getNfts(context.user1.address);
+
+            expect(JSON.stringify(utils.cleanResult(nfts))).to.equal(JSON.stringify(utils.cleanResult(expectedNfts)));
+        });
+    });
+
+    describe("depositETH()", async () => {
+        it("Should revert if amount to deposit is zero", async () => { // Done
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            // Orders to deposit in yearn with amount 0
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositETHOrder(context, context.yearnVaultAddresses.alEthVault, BIG_NUMBER_ZERO);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                        value: ethToDepositAndFees,
+                    }),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if deposit more than available", async () => { // Done, fail at withdrawer
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            // Orders to deposit in yearn with "initial amount x 2" (more than msg.value)
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositETHOrder(context, context.yearnVaultAddresses.alEthVault, ethToDepositAndFees.mul(2));
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                        value: ethToDepositAndFees,
+                    }),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if vault is not added in Operator Storage", async () => { // Done
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            const notWhitelistedVault = Wallet.createRandom().address;
+
+            // Orders to Deposit in yearn
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositETHOrder(context, notWhitelistedVault, ethToDeposit);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                        value: ethToDepositAndFees,
+                    }),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if minVaultAmount is not respected", async () => { // Done
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            // Orders to Deposit in yearn
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositETHOrder(context, context.yearnVaultAddresses.alEthVault, ethToDeposit, UINT256_MAX);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                        value: ethToDepositAndFees,
+                    }),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Create/Deposit in yearn alETH with ETH", async () => {
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            const ethBalanceBefore = await context.user1.getBalance();
+
+            // Orders to Deposit in yearn
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositETHOrder(context, context.yearnVaultAddresses.alEthVault, ethToDeposit);
+
+            // User1 creates the portfolio/NFT
+            const tx = await context.nestedFactory
+                .connect(context.user1)
+                .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                    value: ethToDepositAndFees,
+                });
+
+            // Get the transaction fees
+            const txFees = await tx.wait().then(value => value.gasUsed.mul(value.effectiveGasPrice));
+
+            // User1 must be the owner of NFT n°1
+            expect(await context.nestedAsset.ownerOf(1)).to.be.equal(context.user1.address);
+
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.alEthVault);
+
+            //  Tokens in vault
+            const vaultBalanceReserve = await vault.balanceOf(context.nestedReserve.address);
+            expect(vaultBalanceReserve).to.not.be.equal(BIG_NUMBER_ZERO);
+
+            expect(await context.user1.getBalance()).to.be.equal(ethBalanceBefore.sub(ethToDepositAndFees).sub(txFees));
+
+            // The FeeSplitter must receive the right fee amount
+            expect(await context.WETH.balanceOf(context.feeSplitter.address)).to.be.equal(
+                getExpectedFees(ethToDeposit),
+            );
+
+            const expectedNfts = [
+                {
+                    id: BigNumber.from(1),
+                    assets: [{ token: context.yearnVaultAddresses.alEthVault, qty: vaultBalanceReserve }],
+                },
+            ];
+
+            const nfts = await context.nestedAssetBatcher.getNfts(context.user1.address);
+
+            expect(JSON.stringify(utils.cleanResult(nfts))).to.equal(JSON.stringify(utils.cleanResult(expectedNfts)));
+        });
+    })
+
+    describe("withdraw256()", () => {
+        beforeEach("Create NFT (id 1) with ETH deposited", async () => {
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            // Orders to Deposit in yearn
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositOrder(context, context.yearnVaultAddresses.triCryptoVault, context.WETH.address, ethToDeposit);
+
+            // User1 creates the portfolio/NFT
+            const tx = await context.nestedFactory
+                .connect(context.user1)
+                .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                    value: ethToDepositAndFees,
+                });
+
+        });
+        it("Should revert if amount to withdraw is zero", async () => { // Done
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.triCryptoVault);
+
+            const vaultBalance = await vault.balanceOf(context.nestedReserve.address);
+
+            // Orders to withdraw from yearn curve vault
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdraw256Order(context, context.yearnVaultAddresses.triCryptoVault, BIG_NUMBER_ZERO, context.WETH.address);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: context.WETH.address, amounts: [vaultBalance], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if withdraw more than available", async () => { // Done, fail at withdraw
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.triCryptoVault);
+
+            const vaultBalance = await vault.balanceOf(context.nestedReserve.address);
+
+            // Orders to withdraw from yearn curve vault
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdraw256Order(context, context.yearnVaultAddresses.triCryptoVault, vaultBalance.mul(2), context.WETH.address);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: context.WETH.address, amounts: [vaultBalance], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if vault is not added in Operator Storage", async () => { // Done
+            // Orders to withdraw from yearn curve vault
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdraw256Order(context, context.yearnVaultAddresses.nonWhitelistedVault, BigNumber.from(100), context.WETH.address);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: context.WETH.address, amounts: [BIG_NUMBER_ZERO], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if token is not in Curve pool", async () => { // Done
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.triCryptoVault);
+
+            const vaultBalance = await vault.balanceOf(context.nestedReserve.address);
+
+            // Orders to withdraw from yearn vault and remove liquidity from curve pool
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdraw256Order(context, context.yearnVaultAddresses.triCryptoVault, vaultBalance, USDCEth); // if you pass a no ERC20 address it will return a random fail
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: context.WETH.address, amounts: [vaultBalance], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if minAmountOut is not respected", async () => { // Done
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.triCryptoVault);
+
+            const vaultBalance = await vault.balanceOf(context.nestedReserve.address);
+
+            // Orders to withdraw from yearn vault and remove liquidity from curve pool
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdraw256Order(context, context.yearnVaultAddresses.triCryptoVault, vaultBalance, context.WETH.address, UINT256_MAX);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: context.WETH.address, amounts: [vaultBalance], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Destroy/Withdraw from Yearn", async () => {
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.triCryptoVault);
+
+            const vaultBalance = await vault.balanceOf(context.nestedReserve.address);
+
+            // Orders to withdraw from yearn curve vault
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdraw256Order(context, context.yearnVaultAddresses.triCryptoVault, vaultBalance, context.WETH.address);
+
+            await context.nestedFactory.connect(context.user1).destroy(1, context.WETH.address, orders);
+
+            // All yearn vault token removed from reserve
+            expect(await vault.balanceOf(context.nestedReserve.address)).to.be.equal(BIG_NUMBER_ZERO);
+            expect(await vault.balanceOf(context.nestedFactory.address)).to.be.equal(BIG_NUMBER_ZERO);
+
+            /*
+             * I can't predict the WETH received in the FeeSplitter.
+             * It should be greater than 0.01 WETH, but sub 1% to allow a margin of error
+             */
+            expect(await context.WETH.balanceOf(context.feeSplitter.address)).to.be.gt(
+                getExpectedFees(appendDecimals(1)).sub(getExpectedFees(appendDecimals(1)).div(100)),
+            );
+        });
+    });
+
+    describe("withdraw128()", () => {
+        beforeEach("Create NFT (id 1) with eurt deposited", async () => {
+            // All the amounts for this test
+            const eurtToDeposit = append6Decimals(1000);
+            const eurtToDepositAndFees = eurtToDeposit.add(getExpectedFees(eurtToDeposit));
+
+            // Orders to Deposit in yearn
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositOrder(context, context.yearnVaultAddresses.threeEurVault, EURT, eurtToDeposit);
+
+            // User1 creates the portfolio/NFT
+            await context.nestedFactory
+                .connect(context.user1)
+                .create(0, [{ inputToken: EURT, amount: eurtToDepositAndFees, orders, fromReserve: false }], {
+                    value: 0,
+                });
+        });
+        it("Should revert if amount to withdraw is zero", async () => { // Done
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.threeEurVault);
+
+            const vaultBalance = await vault.balanceOf(context.nestedReserve.address);
+
+            // Orders to withdraw from yearn vault and remove liquidity from curve pool
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdraw128Order(context, context.yearnVaultAddresses.threeEurVault, BIG_NUMBER_ZERO, EURT);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: EURT, amounts: [vaultBalance], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if withdraw more than available", async () => { // Done, fail at withdraw
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.threeEurVault);
+
+            const vaultBalance = await vault.balanceOf(context.nestedReserve.address);
+
+            // Orders to withdraw from yearn vault and remove liquidity from curve pool
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdraw128Order(context, context.yearnVaultAddresses.threeEurVault, vaultBalance.mul(2), EURT);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: EURT, amounts: [vaultBalance], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if vault is not added in Operator Storage", async () => {
+            // Orders to withdraw from yearn curve vault
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdraw128Order(context, context.yearnVaultAddresses.nonWhitelistedVault, BigNumber.from(100), EURT);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: EURT, amounts: [BIG_NUMBER_ZERO], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if token is not in Curve pool", async () => { // Done
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.threeEurVault);
+
+            const vaultBalance = await vault.balanceOf(context.nestedReserve.address);
+
+            // Orders to withdraw from yearn vault and remove liquidity from curve pool
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdraw128Order(context, context.yearnVaultAddresses.threeEurVault, vaultBalance, USDCEth);// if you pass a no ERC20 address it will return a random fail
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: EURT, amounts: [vaultBalance], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if minAmountOut is not respected", async () => { // Done
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.threeEurVault);
+
+            const vaultBalance = await vault.balanceOf(context.nestedReserve.address);
+
+            // Orders to withdraw from yearn vault and remove liquidity from curve pool
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdraw128Order(context, context.yearnVaultAddresses.threeEurVault, vaultBalance, context.WETH.address, UINT256_MAX);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: EURT, amounts: [vaultBalance], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Destroy/Withdraw with EURT from Yearn", async () => {
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.threeEurVault);
+
+            const eurt = mockERC20Factory.attach(EURT);
+
+            const vaultBalance = await vault.balanceOf(context.nestedReserve.address);
+
+            // Orders to withdraw from yearn curve vault
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdraw128Order(context, context.yearnVaultAddresses.threeEurVault, vaultBalance, EURT);
+
+            await context.nestedFactory.connect(context.user1).destroy(1, EURT, orders);
+
+            // All yearn vault token removed from reserve
+            expect(await vault.balanceOf(context.nestedReserve.address)).to.be.equal(BIG_NUMBER_ZERO);
+            expect(await vault.balanceOf(context.nestedFactory.address)).to.be.equal(BIG_NUMBER_ZERO);
+
+            /*
+             * I can't predict the WETH received in the FeeSplitter.
+             * It should be greater than 0.01 WETH, but sub 1% to allow a margin of error
+             */
+            expect(await eurt.balanceOf(context.feeSplitter.address)).to.be.gt(
+                getExpectedFees(append6Decimals(1)).sub(getExpectedFees(append6Decimals(1)).div(100)),
+            );
+
+            expect(await (await eurt.balanceOf(context.user1.address))).to.be.gt(BIG_NUMBER_ZERO);
+        });
+    });
+
+    describe("withdrawETH()", () => {
+        beforeEach("Create NFT (id 1) with ETH deposited", async () => {
+            // All the amounts for this test
+            const ethToDeposit = appendDecimals(1);
+            const ethToDepositAndFees = ethToDeposit.add(getExpectedFees(ethToDeposit));
+
+            // Orders to Deposit in yearn
+            let orders: utils.OrderStruct[] = utils.getYearnCurveDepositETHOrder(context, context.yearnVaultAddresses.alEthVault, ethToDeposit);
+
+            // User1 creates the portfolio/NFT
+            const tx = await context.nestedFactory
+                .connect(context.user1)
+                .create(0, [{ inputToken: ETH, amount: ethToDepositAndFees, orders, fromReserve: false }], {
+                    value: ethToDepositAndFees,
+                });
+        });
+        it("Should revert if amount to withdraw is zero", async () => { // Done
+            // Orders to withdraw from yearn curve vault
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdrawETHOrder(context, context.yearnVaultAddresses.alEthVault, BIG_NUMBER_ZERO);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: context.WETH.address, amounts: [BIG_NUMBER_ZERO], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if withdraw more than available", async () => { // Done
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.alEthVault);
+
+            const vaultBalance = await vault.balanceOf(context.nestedReserve.address);
+
+            // Orders to withdraw from yearn curve vault
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdrawETHOrder(context, context.yearnVaultAddresses.alEthVault, vaultBalance.mul(2));
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: context.WETH.address, amounts: [vaultBalance], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if vault is not added in Operator Storage", async () => { // Done
+            // Orders to withdraw from yearn curve vault
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdrawETHOrder(context, context.yearnVaultAddresses.nonWhitelistedVault, BigNumber.from(100));
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: context.WETH.address, amounts: [BIG_NUMBER_ZERO], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Should revert if minAmountOut is not respected", async () => { // Done
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.alEthVault);
+
+            const vaultBalance = await vault.balanceOf(context.nestedReserve.address);
+
+            // Orders to withdraw from yearn vault and remove liquidity from curve pool
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdrawETHOrder(context, context.yearnVaultAddresses.alEthVault, vaultBalance, UINT256_MAX);
+
+            // User1 creates the portfolio/NFT
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: context.WETH.address, amounts: [vaultBalance], orders, toReserve: true },
+                    ]),
+            ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
+        });
+        it("Destroy/Withdraw from Yearn", async () => {
+            const mockERC20Factory = await ethers.getContractFactory("MockERC20");
+            const vault = mockERC20Factory.attach(context.yearnVaultAddresses.alEthVault);
+
+            const vaultBalance = await vault.balanceOf(context.nestedReserve.address);
+
+            // Orders to withdraw from yearn curve vault
+            let orders: utils.OrderStruct[] = utils.getYearnCurveWithdrawETHOrder(context, context.yearnVaultAddresses.alEthVault, vaultBalance);
+
+            await context.nestedFactory.connect(context.user1).destroy(1, context.WETH.address, orders);
+
+            // All yearn vault token removed from reserve
+            expect(await vault.balanceOf(context.nestedReserve.address)).to.be.equal(BIG_NUMBER_ZERO);
+            expect(await vault.balanceOf(context.nestedFactory.address)).to.be.equal(BIG_NUMBER_ZERO);
+
+            /*
+             * I can't predict the WETH received in the FeeSplitter.
+             * It should be greater than 0.01 WETH, but sub 1% to allow a margin of error
+             */
+            expect(await context.WETH.balanceOf(context.feeSplitter.address)).to.be.gt(
+                getExpectedFees(appendDecimals(1)).sub(getExpectedFees(appendDecimals(1)).div(100)),
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Context 

In the [Yearn app](https://yearn.finance/#/vaults), we can find multiple types of vaults. 
Some of them are Curve vaults where you can stake Curve LP token.

This operator is focused on Yearn Curve LP token vaults.

## How the operator works
There are two steps :
- Add liquidity in the Curve pool
- Interacting with Yearn vaults

The protocols takes one of the curve pool tokens.
![alEth](https://user-images.githubusercontent.com/25029483/170286303-1eb519a8-eff3-41ff-924e-43d673903929.png)
In this Yearn vault, it is the [alETH Curve LP token](https://etherscan.io/address/0xc4c319e2d4d66cca4464c0c2b32c9bd23ebe784e#code) that is used to be staked.

> See also [alETH Curve pool](https://etherscan.io/address/0xc4c319e2d4d66cca4464c0c2b32c9bd23ebe784e#code) smart contract

### Deposit (steps)
_Input => Token from the Curve pool_
Add liquidity in the Curve pool.
Deposit the token in the Yearn Vault.
_Output => Yearn vault token (shares)_
### Withdraw (steps)
_Input => Yearn vault token (shares)_
Withdraw from Yearn and receive the Curve LP token.
Remove liquidity (will burn the LP) and receive one of the pool token.
_Output => Token from the pool_

## Differences betweens Curve pools
Some Curve pools have different interfaces especially on the `remove_liquidity_one_coin` function.
You can find those two different function selectors:
- `remove_liquidity_one_coin(uint256,int128,uint256)`
- `remove_liquidity_one_coin(uint256,uint256,uint256)`

These differences are the consequence of the presence of functions `withdraw128()` and `withdraw256()` in the operator.

## Supported Curve pool types
- [Curve plain pools](https://curve.readthedocs.io/exchange-pools.html#plain-pools) => **100% supported**
    - Curve plain pools without ETH ✔
    - Curve plain pools with ETH ✔
- [Curve lending pools](https://curve.readthedocs.io/exchange-pools.html#plain-pools) => **partialy supported**
    - Curve plain pools without ETH ✔
    - Curve plain pools with ETH 
        - Deposit ✔
        - withdraw non ETH ✔
        - Withdraw ETH ❌
- [Curve factory - pools](https://curve.readthedocs.io/factory-pools.html) => **partialy supported**
    - Curve pool without LP token ✔
    - Metapool with LP token ❌
- [Curve metapool](https://curve.readthedocs.io/exchange-pools.html#metapools) => **not supported** ❌