### PR TITLE
fix: bypass fees regression

### DIFF
--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -489,10 +489,7 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, OwnableProxyDelegatio
         if (success) {
             require(amounts[1] <= _amountToSpend, "NF: OVERSPENT");
             unchecked {
-                uint256 underSpentAmount = _amountToSpend - amounts[1];
-                if (underSpentAmount != 0) {
-                    SafeERC20.safeTransfer(IERC20(_inputToken), _msgSender(), underSpentAmount);
-                }
+                _safeTransferWithFees(IERC20(_inputToken), _amountToSpend - amounts[1], _msgSender(), _nftId);
             }
         } else {
             _safeTransferWithFees(IERC20(_inputToken), _amountToSpend, _msgSender(), _nftId);

--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -489,7 +489,10 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, OwnableProxyDelegatio
         if (success) {
             require(amounts[1] <= _amountToSpend, "NF: OVERSPENT");
             unchecked {
-                _safeTransferWithFees(IERC20(_inputToken), _amountToSpend - amounts[1], _msgSender(), _nftId);
+                uint256 underSpentAmount = _amountToSpend - amounts[1];
+                if (underSpentAmount != 0) {
+                    _safeTransferWithFees(IERC20(_inputToken), underSpentAmount, _msgSender(), _nftId);
+                }
             }
         } else {
             _safeTransferWithFees(IERC20(_inputToken), _amountToSpend, _msgSender(), _nftId);

--- a/test/shared/provider.ts
+++ b/test/shared/provider.ts
@@ -12,5 +12,9 @@ export const expect = chai.expect;
 export const assert = chai.assert;
 
 export const describeOnBscFork =
-    !config.networks.hardhat.forking.enabled && process.env.FORK_CHAINID === "56" ? describe.skip : describe;
+    config.networks.hardhat.forking.enabled && process.env.FORK_CHAINID === "56" ? describe : describe.skip;
+
+export const describeOnEthFork =
+    config.networks.hardhat.forking.enabled && process.env.FORK_CHAINID === "1" ? describe : describe.skip;
+
 export const describeWithoutFork = config.networks.hardhat.forking.enabled ? describe.skip : describe;

--- a/test/unit/FlatOperator.unit.ts
+++ b/test/unit/FlatOperator.unit.ts
@@ -186,4 +186,57 @@ describeWithoutFork("FlatOperator", () => {
         // The NFT is burned
         await expect(context.nestedAsset.ownerOf(1)).to.be.revertedWith("ERC721: owner query for nonexistent token");
     });
+
+    it("remove token from portfolio when destroy() with underspend amount", async () => {
+        // The user add 10 UNI to the portfolio
+        const uniBought = appendDecimals(10);
+        const expectedFee = getExpectedFees(uniBought);
+        const totalToSpend = uniBought.add(expectedFee);
+
+        // Add 10 UNI with FlatOperator
+        let orders: Order[] = [
+            {
+                operator: context.flatOperatorNameBytes32,
+                token: context.mockUNI.address,
+                callData: utils.abiCoder.encode(["address", "uint256"], [context.mockUNI.address, uniBought]),
+            },
+        ];
+
+        // User1 creates the portfolio/NFT and emit event NftCreated
+        await expect(
+            context.nestedFactory.connect(context.user1).create(0, [
+                {
+                    inputToken: context.mockUNI.address,
+                    amount: totalToSpend,
+                    orders,
+                    fromReserve: false,
+                },
+            ]),
+        )
+            .to.emit(context.nestedFactory, "NftCreated")
+            .withArgs(1, 0);
+
+        // Remove only 1 UNI in the order, hence there is still holdings leading to underspend amount
+        let orders_underspend: Order[] = [
+            {
+                operator: context.flatOperatorNameBytes32,
+                token: context.mockUNI.address,
+                callData: utils.abiCoder.encode(["address", "uint256"], [context.mockUNI.address, appendDecimals(1)]),
+            },
+        ];
+        await context.nestedFactory.connect(context.user1).destroy(1, context.mockUNI.address, orders_underspend);
+
+        // UNI from create and from destroy to FeeSplitter (so, two times 1% of 10 UNI)
+        expect(await context.mockUNI.balanceOf(context.feeSplitter.address)).to.be.equal(
+            getExpectedFees(uniBought).mul(2),
+        );
+
+        // No holdings for NFT 1
+        expect(await context.nestedRecords.getAssetTokens(1).then(value => value.toString())).to.be.equal(
+            [].toString(),
+        );
+
+        // The NFT is burned
+        await expect(context.nestedAsset.ownerOf(1)).to.be.revertedWith("ERC721: owner query for nonexistent token");
+    });
 });


### PR DESCRIPTION
[CodeArena issue](https://github.com/code-423n4/2022-02-nested-findings/issues/27) was fixed by [PR 100](https://github.com/NestedFi/nested-core-lego/pull/100) but [PR 111](https://github.com/NestedFi/nested-core-lego/pull/111) introduced a regression.
The current PR fix the regression from [PR 111](https://github.com/NestedFi/nested-core-lego/pull/111).
A test was added to ensure the regression is fixed and tested.